### PR TITLE
Hadoop 18073 delete object

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/MultiObjectDeleteException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/MultiObjectDeleteException.java
@@ -25,6 +25,10 @@ import software.amazon.awssdk.services.s3.model.S3Error;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
+/**
+ * Exception raised in {@link S3AFileSystem#deleteObjects} when
+ * one or more of the keys could not be deleted.
+ */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
 public class MultiObjectDeleteException extends RuntimeException {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/MultiObjectDeleteException.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/MultiObjectDeleteException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.s3a;
+
+import java.util.List;
+
+import software.amazon.awssdk.services.s3.model.S3Error;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+
+@InterfaceAudience.Public
+@InterfaceStability.Unstable
+public class MultiObjectDeleteException extends RuntimeException {
+
+  private final List<S3Error> errors;
+
+  public MultiObjectDeleteException(List<S3Error> errors) {
+    super(errors.toString());
+    this.errors = errors;
+  }
+
+  public List<S3Error> errors() { return errors; }
+}

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -54,9 +54,6 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkBaseException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsResult;
-import com.amazonaws.services.s3.model.MultiObjectDeleteException;
 import com.amazonaws.services.s3.model.SelectObjectContentRequest;
 import com.amazonaws.services.s3.model.SelectObjectContentResult;
 import com.amazonaws.services.s3.model.UploadPartRequest;
@@ -82,13 +79,22 @@ import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.transfer.s3.CompletedCopy;
 import software.amazon.awssdk.transfer.s3.CompletedFileUpload;
@@ -1297,10 +1303,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * Set the client -used in mocking tests to force in a different client.
    * @param client client.
    */
-  protected void setAmazonS3Client(AmazonS3 client) {
-    Preconditions.checkNotNull(client, "client");
-    LOG.debug("Setting S3 client to {}", client);
-    s3 = client;
+  protected void setAmazonS3Client(Pair<AmazonS3, S3Client> client) {
+    Preconditions.checkNotNull(client.getLeft(), "client");
+    Preconditions.checkNotNull(client.getRight(), "clientV2");
+    LOG.debug("Setting S3 client to {}", client.getLeft());
+    LOG.debug("Setting S3V2 client to {}", client.getRight());
+    s3 = client.getLeft();
+    s3V2 = client.getRight();
 
     // Need to use a new TransferManager that uses the new client.
     // Also, using a new TransferManager requires a new threadpool as the old
@@ -2290,7 +2299,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
     @Override
     public void removeKeys(
-            final List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+            final List<ObjectIdentifier> keysToDelete,
             final boolean deleteFakeDir)
         throws MultiObjectDeleteException, AmazonClientException, IOException {
       auditSpan.activate();
@@ -2654,7 +2663,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
               changeTracker.processMetadata(headObjectResponse, operation);
             }
             return headObjectResponse;
-          } catch(AwsServiceException ase) {
+          } catch (AwsServiceException ase) {
             if (!isObjectNotFound(ase)) {
               // file not found is not considered a failure of the call,
               // so only switch the duration tracker to update failure
@@ -2807,8 +2816,9 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
             incrementStatistic(OBJECT_DELETE_OBJECTS);
             trackDurationOfInvocation(getDurationTrackerFactory(),
                 OBJECT_DELETE_REQUEST.getSymbol(),
-                () -> s3.deleteObject(getRequestFactory()
-                    .newDeleteObjectRequest(key)));
+                () -> s3V2.deleteObject(getRequestFactory()
+                    .newDeleteObjectRequestBuilder(key)
+                    .build()));
             return null;
           });
     }
@@ -2870,40 +2880,41 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * @return the AWS response
    * @throws MultiObjectDeleteException one or more of the keys could not
    * be deleted.
-   * @throws AmazonClientException amazon-layer failure.
+   * @throws AwsServiceException amazon-layer failure.
    */
   @Retries.RetryRaw
-  private DeleteObjectsResult deleteObjects(DeleteObjectsRequest deleteRequest)
-      throws MultiObjectDeleteException, AmazonClientException, IOException {
+  private DeleteObjectsResponse deleteObjects(DeleteObjectsRequest deleteRequest)
+      throws MultiObjectDeleteException, AwsServiceException, IOException {
     incrementWriteOperations();
     BulkDeleteRetryHandler retryHandler =
         new BulkDeleteRetryHandler(createStoreContext());
-    int keyCount = deleteRequest.getKeys().size();
+    int keyCount = deleteRequest.delete().objects().size();
     try(DurationInfo ignored =
             new DurationInfo(LOG, false, "DELETE %d keys",
                 keyCount)) {
-      return invoker.retryUntranslated("delete",
-          DELETE_CONSIDERED_IDEMPOTENT,
-          (text, e, r, i) -> {
-            // handle the failure
-            retryHandler.bulkDeleteRetried(deleteRequest, e);
-          },
-          // duration is tracked in the bulk delete counters
-          trackDurationOfOperation(getDurationTrackerFactory(),
-              OBJECT_BULK_DELETE_REQUEST.getSymbol(), () -> {
+      DeleteObjectsResponse response =
+          invoker.retryUntranslated("delete", DELETE_CONSIDERED_IDEMPOTENT, (text, e, r, i) -> {
+                // handle the failure
+                retryHandler.bulkDeleteRetried(deleteRequest, e);
+              },
+              // duration is tracked in the bulk delete counters
+              trackDurationOfOperation(getDurationTrackerFactory(), OBJECT_BULK_DELETE_REQUEST.getSymbol(), () -> {
                 incrementStatistic(OBJECT_DELETE_OBJECTS, keyCount);
-                return s3.deleteObjects(deleteRequest);
-            }));
-    } catch (MultiObjectDeleteException e) {
-      // one or more of the keys could not be deleted.
-      // log and rethrow
-      List<MultiObjectDeleteException.DeleteError> errors = e.getErrors();
-      LOG.debug("Partial failure of delete, {} errors", errors.size(), e);
-      for (MultiObjectDeleteException.DeleteError error : errors) {
-        LOG.debug("{}: \"{}\" - {}",
-            error.getKey(), error.getCode(), error.getMessage());
+                return s3V2.deleteObjects(deleteRequest);
+              }));
+
+      if (!response.errors().isEmpty()) {
+        // one or more of the keys could not be deleted.
+        // log and then throw
+        List<S3Error> errors = response.errors();
+        LOG.debug("Partial failure of delete, {} errors", errors.size());
+        for (S3Error error : errors) {
+          LOG.debug("{}: \"{}\" - {}", error.key(), error.code(), error.message());
+        }
+        throw new MultiObjectDeleteException(errors);
       }
-      throw e;
+
+      return response;
     }
   }
 
@@ -3104,56 +3115,57 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * be deleted in a multiple object delete operation.
    * The number of rejected objects will be added to the metric
    * {@link Statistic#FILES_DELETE_REJECTED}.
-   * @throws AmazonClientException other amazon-layer failure.
+   * @throws AwsServiceException other amazon-layer failure.
    */
   @Retries.RetryRaw
   private void removeKeysS3(
-          List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+          List<ObjectIdentifier> keysToDelete,
           boolean deleteFakeDir)
-      throws MultiObjectDeleteException, AmazonClientException,
-      IOException {
+      throws MultiObjectDeleteException, AwsServiceException, IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Initiating delete operation for {} objects",
           keysToDelete.size());
-      for (DeleteObjectsRequest.KeyVersion key : keysToDelete) {
-        LOG.debug(" {} {}", key.getKey(),
-            key.getVersion() != null ? key.getVersion() : "");
+      for (ObjectIdentifier key : keysToDelete) {
+        LOG.debug(" {} {}", key.key(),
+            key.versionId() != null ? key.versionId() : "");
       }
     }
     if (keysToDelete.isEmpty()) {
       // exit fast if there are no keys to delete
       return;
     }
-    for (DeleteObjectsRequest.KeyVersion keyVersion : keysToDelete) {
-      blockRootDelete(keyVersion.getKey());
+    for (ObjectIdentifier keyVersion : keysToDelete) {
+      blockRootDelete(keyVersion.key());
     }
     try {
       if (enableMultiObjectsDelete) {
         if (keysToDelete.size() <= pageSize) {
           deleteObjects(getRequestFactory()
-                  .newBulkDeleteRequest(keysToDelete));
+              .newBulkDeleteRequestBuilder(keysToDelete)
+              .build());
         } else {
           // Multi object deletion of more than 1000 keys is not supported
           // by s3. So we are paging the keys by page size.
           LOG.debug("Partitioning the keys to delete as it is more than " +
                   "page size. Number of keys: {}, Page size: {}",
                   keysToDelete.size(), pageSize);
-          for (List<DeleteObjectsRequest.KeyVersion> batchOfKeysToDelete :
+          for (List<ObjectIdentifier> batchOfKeysToDelete :
                   Lists.partition(keysToDelete, pageSize)) {
             deleteObjects(getRequestFactory()
-                    .newBulkDeleteRequest(batchOfKeysToDelete));
+                .newBulkDeleteRequestBuilder(batchOfKeysToDelete)
+                .build());
           }
         }
       } else {
-        for (DeleteObjectsRequest.KeyVersion keyVersion : keysToDelete) {
-          deleteObject(keyVersion.getKey());
+        for (ObjectIdentifier keyVersion : keysToDelete) {
+          deleteObject(keyVersion.key());
         }
       }
     } catch (MultiObjectDeleteException ex) {
       // partial delete.
       // Update the stats with the count of the actual number of successful
       // deletions.
-      int rejected = ex.getErrors().size();
+      int rejected = ex.errors().size();
       noteDeleted(keysToDelete.size() - rejected, deleteFakeDir);
       incrementStatistic(FILES_DELETE_REJECTED, rejected);
       throw ex;
@@ -3186,15 +3198,15 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    * a mistaken attempt to delete the root directory.
    * @throws MultiObjectDeleteException one or more of the keys could not
    * be deleted in a multiple object delete operation.
-   * @throws AmazonClientException amazon-layer failure.
+   * @throws AwsServiceException amazon-layer failure.
    * @throws IOException other IO Exception.
    */
   @VisibleForTesting
   @Retries.RetryRaw
   public void removeKeys(
-      final List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+      final List<ObjectIdentifier> keysToDelete,
       final boolean deleteFakeDir)
-      throws MultiObjectDeleteException, AmazonClientException,
+      throws MultiObjectDeleteException, AwsServiceException,
       IOException {
     try (DurationInfo ignored = new DurationInfo(LOG, false,
             "Deleting %d keys", keysToDelete.size())) {
@@ -4418,22 +4430,22 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
    */
   @Retries.RetryExceptionsSwallowed
   private void deleteUnnecessaryFakeDirectories(Path path) {
-    List<DeleteObjectsRequest.KeyVersion> keysToRemove = new ArrayList<>();
+    List<ObjectIdentifier> keysToRemove = new ArrayList<>();
     while (!path.isRoot()) {
       String key = pathToKey(path);
       key = (key.endsWith("/")) ? key : (key + "/");
       LOG.trace("To delete unnecessary fake directory {} for {}", key, path);
-      keysToRemove.add(new DeleteObjectsRequest.KeyVersion(key));
+      keysToRemove.add(ObjectIdentifier.builder().key(key).build());
       path = path.getParent();
     }
     try {
       removeKeys(keysToRemove, true);
-    } catch(AmazonClientException | IOException e) {
+    } catch (AwsServiceException | IOException e) {
       instrumentation.errorIgnored();
       if (LOG.isDebugEnabled()) {
         StringBuilder sb = new StringBuilder();
-        for(DeleteObjectsRequest.KeyVersion kv : keysToRemove) {
-          sb.append(kv.getKey()).append(",");
+        for (ObjectIdentifier kv : keysToRemove) {
+          sb.append(kv.key()).append(",");
         }
         LOG.debug("While deleting keys {} ", sb.toString(), e);
       }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -2889,16 +2889,18 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     BulkDeleteRetryHandler retryHandler =
         new BulkDeleteRetryHandler(createStoreContext());
     int keyCount = deleteRequest.delete().objects().size();
-    try(DurationInfo ignored =
+    try (DurationInfo ignored =
             new DurationInfo(LOG, false, "DELETE %d keys",
                 keyCount)) {
       DeleteObjectsResponse response =
-          invoker.retryUntranslated("delete", DELETE_CONSIDERED_IDEMPOTENT, (text, e, r, i) -> {
+          invoker.retryUntranslated("delete", DELETE_CONSIDERED_IDEMPOTENT,
+              (text, e, r, i) -> {
                 // handle the failure
                 retryHandler.bulkDeleteRetried(deleteRequest, e);
               },
               // duration is tracked in the bulk delete counters
-              trackDurationOfOperation(getDurationTrackerFactory(), OBJECT_BULK_DELETE_REQUEST.getSymbol(), () -> {
+              trackDurationOfOperation(getDurationTrackerFactory(),
+                  OBJECT_BULK_DELETE_REQUEST.getSymbol(), () -> {
                 incrementStatistic(OBJECT_DELETE_OBJECTS, keyCount);
                 return s3V2.deleteObjects(deleteRequest);
               }));
@@ -3125,17 +3127,17 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
     if (LOG.isDebugEnabled()) {
       LOG.debug("Initiating delete operation for {} objects",
           keysToDelete.size());
-      for (ObjectIdentifier key : keysToDelete) {
-        LOG.debug(" {} {}", key.key(),
-            key.versionId() != null ? key.versionId() : "");
+      for (ObjectIdentifier objectIdentifier : keysToDelete) {
+        LOG.debug(" {} {}", objectIdentifier.key(),
+            objectIdentifier.versionId() != null ? objectIdentifier.versionId() : "");
       }
     }
     if (keysToDelete.isEmpty()) {
       // exit fast if there are no keys to delete
       return;
     }
-    for (ObjectIdentifier keyVersion : keysToDelete) {
-      blockRootDelete(keyVersion.key());
+    for (ObjectIdentifier objectIdentifier : keysToDelete) {
+      blockRootDelete(objectIdentifier.key());
     }
     try {
       if (enableMultiObjectsDelete) {
@@ -3157,8 +3159,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           }
         }
       } else {
-        for (ObjectIdentifier keyVersion : keysToDelete) {
-          deleteObject(keyVersion.key());
+        for (ObjectIdentifier objectIdentifier : keysToDelete) {
+          deleteObject(objectIdentifier.key());
         }
       }
     } catch (MultiObjectDeleteException ex) {
@@ -4444,8 +4446,8 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
       instrumentation.errorIgnored();
       if (LOG.isDebugEnabled()) {
         StringBuilder sb = new StringBuilder();
-        for (ObjectIdentifier kv : keysToRemove) {
-          sb.append(kv.key()).append(",");
+        for (ObjectIdentifier objectIdentifier : keysToRemove) {
+          sb.append(objectIdentifier.key()).append(",");
         }
         LOG.debug("While deleting keys {} ", sb.toString(), e);
       }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -191,9 +191,11 @@ public final class S3AUtils {
 
     AwsServiceException ase = (AwsServiceException) exception;
 
-    int status = ase.statusCode();
+    if (ase.awsErrorDetails() != null) {
+      message = message + ":" + ase.awsErrorDetails().errorCode();
+    }
     IOException ioe;
-    message = message + ":" + ase.awsErrorDetails().errorCode();
+    int status = ase.statusCode();
     switch (status) {
 
     case 403:
@@ -215,7 +217,7 @@ public final class S3AUtils {
     default:
       // no specific exit code. Choose an IOE subclass based on the class
       // of the caught exception
-      ioe = new IOException();
+      ioe = new IOException(message);
       break;
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -24,8 +24,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ListNextBatchOfObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
@@ -38,19 +36,22 @@ import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.impl.PutObjectOptions;
 
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
-import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 
 /**
@@ -276,18 +277,18 @@ public interface RequestFactory {
       int maxKeys);
 
   /**
-   * Create a request to delete a single object.
+   * Create a request builder to delete a single object.
    * @param key object to delete
-   * @return the request
+   * @return the request builder.
    */
-  DeleteObjectRequest newDeleteObjectRequest(String key);
+  DeleteObjectRequest.Builder newDeleteObjectRequestBuilder(String key);
 
   /**
-   * Bulk delete request.
+   * Create a request builder to delete objects in bulk.
    * @param keysToDelete list of keys to delete.
-   * @return the request
+   * @return the request builder.
    */
-  DeleteObjectsRequest newBulkDeleteRequest(
-          List<DeleteObjectsRequest.KeyVersion> keysToDelete);
+  DeleteObjectsRequest.Builder newBulkDeleteRequestBuilder(
+          List<ObjectIdentifier> keysToDelete);
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/BulkDeleteRetryHandler.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/BulkDeleteRetryHandler.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.fs.s3a.impl;
 
 import java.util.List;
 
-import com.amazonaws.SdkClientException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +27,10 @@ import org.apache.hadoop.fs.s3a.AWSClientIOException;
 import org.apache.hadoop.fs.s3a.S3AStorageStatistics;
 import org.apache.hadoop.fs.s3a.Statistic;
 import org.apache.hadoop.fs.s3a.statistics.S3AStatisticsContext;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.isThrottleException;
 import static org.apache.hadoop.fs.s3a.Statistic.IGNORED_ERRORS;
@@ -113,15 +115,15 @@ public class BulkDeleteRetryHandler extends AbstractStoreOperation {
    * @param deleteRequest request which failed.
    */
   private void onDeleteThrottled(final DeleteObjectsRequest deleteRequest) {
-    final List<DeleteObjectsRequest.KeyVersion> keys = deleteRequest.getKeys();
+    final List<ObjectIdentifier> keys = deleteRequest.delete().objects();
     final int size = keys.size();
     incrementStatistic(STORE_IO_THROTTLED, size);
     instrumentation.addValueToQuantiles(STORE_IO_THROTTLE_RATE, size);
     THROTTLE_LOG.info(
         "Bulk delete {} keys throttled -first key = {}; last = {}",
         size,
-        keys.get(0).getKey(),
-        keys.get(size - 1).getKey());
+        keys.get(0).key(),
+        keys.get(size - 1).key());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OperationCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/OperationCallbacks.java
@@ -22,16 +22,15 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.List;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.MultiObjectDeleteException;
-import com.amazonaws.services.s3.transfer.model.CopyResult;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.InvalidRequestException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.MultiObjectDeleteException;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
@@ -142,14 +141,14 @@ public interface OperationCallbacks {
    * a mistaken attempt to delete the root directory.
    * @throws MultiObjectDeleteException one or more of the keys could not
    * be deleted in a multiple object delete operation.
-   * @throws AmazonClientException amazon-layer failure.
+   * @throws AwsServiceException amazon-layer failure.
    * @throws IOException other IO Exception.
    */
   @Retries.RetryRaw
   void removeKeys(
-          List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+          List<ObjectIdentifier> keysToDelete,
           boolean deleteFakeDir)
-      throws MultiObjectDeleteException, AmazonClientException,
+      throws MultiObjectDeleteException, AwsServiceException,
       IOException;
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
@@ -581,9 +581,9 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
     // who is trying to debug why objects are no longer there.
     if (LOG.isDebugEnabled()) {
       LOG.debug("Initiating delete operation for {} objects", keys.size());
-      for (ObjectIdentifier key : keys) {
-        LOG.debug(" {} {}", key.key(),
-            key.versionId() != null ? key.versionId() : "");
+      for (ObjectIdentifier objectIdentifier : keys) {
+        LOG.debug(" {} {}", objectIdentifier.key(),
+            objectIdentifier.versionId() != null ? objectIdentifier.versionId() : "");
       }
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RenameOperation.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.SdkBaseException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +42,8 @@ import org.apache.hadoop.fs.s3a.S3ObjectAttributes;
 import org.apache.hadoop.fs.s3a.Tristate;
 import org.apache.hadoop.util.DurationInfo;
 import org.apache.hadoop.util.OperationDuration;
+
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import static org.apache.hadoop.fs.s3a.S3AUtils.translateException;
 import static org.apache.hadoop.fs.store.audit.AuditingFunctions.callableWithinAuditSpan;
@@ -122,7 +123,7 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
   /**
    * list of keys to delete on the next (bulk) delete call.
    */
-  private final List<DeleteObjectsRequest.KeyVersion> keysToDelete =
+  private final List<ObjectIdentifier> keysToDelete =
       new ArrayList<>();
 
   /**
@@ -199,7 +200,7 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
    */
   private void queueToDelete(Path path, String key) {
     LOG.debug("Queueing to delete {}", path);
-    keysToDelete.add(new DeleteObjectsRequest.KeyVersion(key));
+    keysToDelete.add(ObjectIdentifier.builder().key(key).build());
   }
 
   /**
@@ -572,7 +573,7 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
    */
   @Retries.RetryTranslated
   private void removeSourceObjects(
-      final List<DeleteObjectsRequest.KeyVersion> keys)
+      final List<ObjectIdentifier> keys)
       throws IOException {
     // remove the keys
 
@@ -580,9 +581,9 @@ public class RenameOperation extends ExecutingStoreOperation<Long> {
     // who is trying to debug why objects are no longer there.
     if (LOG.isDebugEnabled()) {
       LOG.debug("Initiating delete operation for {} objects", keys.size());
-      for (DeleteObjectsRequest.KeyVersion key : keys) {
-        LOG.debug(" {} {}", key.getKey(),
-            key.getVersion() != null ? key.getVersion() : "");
+      for (ObjectIdentifier key : keys) {
+        LOG.debug(" {} {}", key.key(),
+            key.versionId() != null ? key.versionId() : "");
       }
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -28,8 +28,6 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ListNextBatchOfObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
@@ -46,6 +44,8 @@ import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
 import software.amazon.awssdk.services.s3.model.CompletedPart;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -55,6 +55,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.MetadataDirective;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.StorageClass;
@@ -620,17 +621,17 @@ public class RequestFactoryImpl implements RequestFactory {
   }
 
   @Override
-  public DeleteObjectRequest newDeleteObjectRequest(String key) {
-    return prepareRequest(new DeleteObjectRequest(bucket, key));
+  public DeleteObjectRequest.Builder newDeleteObjectRequestBuilder(String key) {
+    return prepareV2Request(DeleteObjectRequest.builder().bucket(bucket).key(key));
   }
 
   @Override
-  public DeleteObjectsRequest newBulkDeleteRequest(
-          List<DeleteObjectsRequest.KeyVersion> keysToDelete) {
-    return prepareRequest(
-        new DeleteObjectsRequest(bucket)
-            .withKeys(keysToDelete)
-            .withQuiet(true));
+  public DeleteObjectsRequest.Builder newBulkDeleteRequestBuilder(
+          List<ObjectIdentifier> keysToDelete) {
+    return prepareV2Request(DeleteObjectsRequest
+        .builder()
+        .bucket(bucket)
+        .delete(d -> d.objects(keysToDelete).quiet(true)));
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerTool.java
@@ -32,10 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.MultiObjectDeleteException;
 import org.apache.hadoop.classification.VisibleForTesting;
+import org.apache.hadoop.fs.s3a.MultiObjectDeleteException;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,6 +58,9 @@ import org.apache.hadoop.fs.s3a.s3guard.S3GuardTool;
 import org.apache.hadoop.fs.shell.CommandFormat;
 import org.apache.hadoop.util.DurationInfo;
 import org.apache.hadoop.util.ExitUtil;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import static org.apache.hadoop.fs.s3a.Constants.AUTHORITATIVE_PATH;
 import static org.apache.hadoop.fs.s3a.Constants.BULK_DELETE_PAGE_SIZE;
@@ -778,7 +779,7 @@ public final class MarkerTool extends S3GuardTool {
   private MarkerPurgeSummary purgeMarkers(
       final DirMarkerTracker tracker,
       final int deletePageSize)
-      throws MultiObjectDeleteException, AmazonClientException, IOException {
+      throws MultiObjectDeleteException, AwsServiceException, IOException {
 
     MarkerPurgeSummary summary = new MarkerPurgeSummary();
     // we get a map of surplus markers to delete.
@@ -786,13 +787,13 @@ public final class MarkerTool extends S3GuardTool {
         = tracker.getSurplusMarkers();
     int size = markers.size();
     // build a list from the strings in the map
-    List<DeleteObjectsRequest.KeyVersion> collect =
+    List<ObjectIdentifier> collect =
         markers.values().stream()
-            .map(p -> new DeleteObjectsRequest.KeyVersion(p.getKey()))
+            .map(p -> ObjectIdentifier.builder().key(p.getKey()).build())
             .collect(Collectors.toList());
     // build an array list for ease of creating the lists of
     // keys in each page through the subList() method.
-    List<DeleteObjectsRequest.KeyVersion> markerKeys =
+    List<ObjectIdentifier> markerKeys =
         new ArrayList<>(collect);
 
     // now randomize. Why so? if the list spans multiple S3 partitions,
@@ -813,7 +814,7 @@ public final class MarkerTool extends S3GuardTool {
     while (start < size) {
       // end is one past the end of the page
       int end = Math.min(start + deletePageSize, size);
-      List<DeleteObjectsRequest.KeyVersion> page = markerKeys.subList(start,
+      List<ObjectIdentifier> page = markerKeys.subList(start,
           end);
       once("Remove S3 Keys",
           tracker.getBasePath().toString(), () ->

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerToolOperations.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerToolOperations.java
@@ -21,15 +21,15 @@ package org.apache.hadoop.fs.s3a.tools;
 import java.io.IOException;
 import java.util.List;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.MultiObjectDeleteException;
-
 import org.apache.hadoop.fs.InvalidRequestException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.MultiObjectDeleteException;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 /**
  * Operations which must be offered by the store for {@link MarkerTool}.
@@ -62,14 +62,14 @@ public interface MarkerToolOperations {
    * a mistaken attempt to delete the root directory.
    * @throws MultiObjectDeleteException one or more of the keys could not
    * be deleted in a multiple object delete operation.
-   * @throws AmazonClientException amazon-layer failure.
+   * @throws AwsServiceException amazon-layer failure.
    * @throws IOException other IO Exception.
    */
   @Retries.RetryMixed
   void removeKeys(
-      List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+      List<ObjectIdentifier> keysToDelete,
       boolean deleteFakeDir)
-      throws MultiObjectDeleteException, AmazonClientException,
+      throws MultiObjectDeleteException, AwsServiceException,
              IOException;
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerToolOperationsImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/tools/MarkerToolOperationsImpl.java
@@ -21,14 +21,14 @@ package org.apache.hadoop.fs.s3a.tools;
 import java.io.IOException;
 import java.util.List;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.MultiObjectDeleteException;
-
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.MultiObjectDeleteException;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.impl.OperationCallbacks;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 /**
  * Implement the marker tool operations by forwarding to the
@@ -55,9 +55,9 @@ public class MarkerToolOperationsImpl implements MarkerToolOperations {
 
   @Override
   public void removeKeys(
-      final List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+      final List<ObjectIdentifier> keysToDelete,
       final boolean deleteFakeDir)
-      throws MultiObjectDeleteException, AmazonClientException, IOException {
+      throws MultiObjectDeleteException, AwsServiceException, IOException {
     operationCallbacks.removeKeys(keysToDelete, deleteFakeDir
     );
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AFailureHandling.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 
@@ -33,6 +31,8 @@ import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -115,12 +115,12 @@ public class ITestS3AFailureHandling extends AbstractS3ATestBase {
     }
   }
 
-  private List<DeleteObjectsRequest.KeyVersion> buildDeleteRequest(
+  private List<ObjectIdentifier> buildDeleteRequest(
       final String[] keys) {
-    List<DeleteObjectsRequest.KeyVersion> request = new ArrayList<>(
+    List<ObjectIdentifier> request = new ArrayList<>(
         keys.length);
     for (String key : keys) {
-      request.add(new DeleteObjectsRequest.KeyVersion(key));
+      request.add(ObjectIdentifier.builder().key(key).build());
     }
     return request;
   }
@@ -156,12 +156,13 @@ public class ITestS3AFailureHandling extends AbstractS3ATestBase {
     // create a span, expect it to be activated.
     fs.getAuditSpanSource().createSpan(StoreStatisticNames.OP_DELETE,
         csvPath.toString(), null);
-    List<DeleteObjectsRequest.KeyVersion> keys
+    List<ObjectIdentifier> keys
         = buildDeleteRequest(
             new String[]{
                 fs.pathToKey(csvPath),
                 "missing-key.csv"
             });
+    // TODO:WiP: missing test?
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -51,6 +51,8 @@ import org.apache.hadoop.fs.s3a.test.MinimalWriteOperationHelperCallbacks;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
 import org.apache.hadoop.util.Progressable;
 
+import software.amazon.awssdk.services.s3.S3Client;
+
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.noopAuditor;
 import static org.apache.hadoop.fs.statistics.IOStatisticsSupport.stubDurationTrackerFactory;
 import static org.apache.hadoop.util.Preconditions.checkNotNull;
@@ -205,7 +207,7 @@ public class MockS3AFileSystem extends S3AFileSystem {
    * @param client client.
    */
   @Override
-  public void setAmazonS3Client(AmazonS3 client) {
+  public void setAmazonS3Client(Pair<AmazonS3, S3Client> client) {
     LOG.debug("Setting S3 client to {}", client);
     super.setAmazonS3Client(client);
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AGetFileStatus.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AGetFileStatus.java
@@ -150,15 +150,17 @@ public class TestS3AGetFileStatus extends AbstractS3AMockTest {
   private void setupListMocks(List<CommonPrefix> prefixes,
       List<S3Object> s3Objects) {
     // V1 list API mock
-    ListObjectsResponse v1Response = mock(ListObjectsResponse.class);
-    when(v1Response.commonPrefixes()).thenReturn(prefixes);
-    when(v1Response.contents()).thenReturn(s3Objects);
+    ListObjectsResponse v1Response = ListObjectsResponse.builder()
+        .commonPrefixes(prefixes)
+        .contents(s3Objects)
+        .build();
     when(s3V2.listObjects(any(ListObjectsRequest.class))).thenReturn(v1Response);
 
     // V2 list API mock
-    ListObjectsV2Response v2Result = mock(ListObjectsV2Response.class);
-    when(v2Result.commonPrefixes()).thenReturn(prefixes);
-    when(v2Result.contents()).thenReturn(s3Objects);
+    ListObjectsV2Response v2Result = ListObjectsV2Response.builder()
+        .commonPrefixes(prefixes)
+        .contents(s3Objects)
+        .build();
     when(s3V2.listObjectsV2(
         any(software.amazon.awssdk.services.s3.model.ListObjectsV2Request.class))).thenReturn(
         v2Result);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
@@ -32,8 +32,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 
 import org.apache.hadoop.util.Sets;
 import org.assertj.core.api.Assertions;
@@ -51,7 +49,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.s3a.AWSClientIOException;
 import org.apache.hadoop.fs.s3a.MockS3AFileSystem;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.fs.s3a.commit.AbstractS3ACommitter;
@@ -71,6 +68,8 @@ import org.apache.hadoop.mapreduce.task.JobContextImpl;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.*;
@@ -475,7 +474,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     writeOutputFile(tac.getTaskAttemptID(), attemptPath,
         UUID.randomUUID().toString(), 10);
 
-    intercept(AWSClientIOException.class,
+    intercept(IOException.class,
         "Fail on init 1",
         "Should fail during init",
         () -> committer.commitTask(tac));
@@ -503,7 +502,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     writeOutputFile(tac.getTaskAttemptID(), attemptPath,
         UUID.randomUUID().toString(), 10);
 
-    intercept((Class<? extends Exception>) AWSClientIOException.class,
+    intercept(IOException.class,
         "Fail on upload 2",
         "Should fail during upload",
         () -> {
@@ -515,7 +514,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
         1, results.getUploads().size());
     assertEquals("Should abort the upload",
         results.getUploads().get(0),
-        results.getAborts().get(0).getUploadId());
+        results.getAborts().get(0).uploadId());
     assertPathDoesNotExist(fs, "Should remove the attempt path",
         attemptPath);
   }
@@ -534,7 +533,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     writeOutputFile(tac.getTaskAttemptID(), attemptPath,
         UUID.randomUUID().toString(), 10);
 
-    intercept((Class<? extends Exception>) AWSClientIOException.class,
+    intercept(IOException.class,
         "Fail on upload 5",
         "Should fail during upload",
         () -> {
@@ -566,7 +565,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     writeOutputFile(tac.getTaskAttemptID(), attemptPath,
         UUID.randomUUID().toString(), 10);
 
-    intercept((Class<? extends Exception>) AWSClientIOException.class,
+    intercept(IOException.class,
         "Fail on upload 5",
         "Should suppress abort failure, propagate upload failure",
         ()-> {
@@ -639,7 +638,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     errors.failOnCommit(5);
     setMockLogLevel(MockS3AFileSystem.LOG_NAME);
 
-    intercept(AWSClientIOException.class,
+    intercept(IOException.class,
         "Fail on commit 5",
         "Should propagate the commit failure",
         () -> {
@@ -650,7 +649,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     Set<String> commits = results.getCommits()
         .stream()
         .map(commit ->
-            "s3a://" + commit.getBucketName() + "/" + commit.getKey())
+            "s3a://" + commit.bucket() + "/" + commit.key())
         .collect(Collectors.toSet());
 
     Set<String> deletes = results.getDeletes()
@@ -730,14 +729,14 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
   private static Set<String> getAbortedIds(
       List<AbortMultipartUploadRequest> aborts) {
     return aborts.stream()
-        .map(AbortMultipartUploadRequest::getUploadId)
+        .map(AbortMultipartUploadRequest::uploadId)
         .collect(Collectors.toSet());
   }
 
   private static Set<String> getCommittedIds(
       List<CompleteMultipartUploadRequest> commits) {
     return commits.stream()
-        .map(CompleteMultipartUploadRequest::getUploadId)
+        .map(CompleteMultipartUploadRequest::uploadId)
         .collect(Collectors.toSet());
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingCommitter.java
@@ -70,6 +70,8 @@ import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.mapreduce.task.JobContextImpl;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 
+import software.amazon.awssdk.services.s3.S3Client;
+
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.*;
 import static org.apache.hadoop.fs.s3a.commit.InternalCommitterConstants.*;
@@ -112,7 +114,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
   // created in Before
   private StagingTestBase.ClientResults results = null;
   private StagingTestBase.ClientErrors errors = null;
-  private AmazonS3 mockClient = null;
+  private Pair<AmazonS3, S3Client> mockClient = null;
   private File tmpDir;
 
   /**
@@ -645,7 +647,6 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
           return jobCommitter.toString();
         });
 
-
     Set<String> commits = results.getCommits()
         .stream()
         .map(commit ->
@@ -655,7 +656,7 @@ public class TestStagingCommitter extends StagingTestBase.MiniDFSTest {
     Set<String> deletes = results.getDeletes()
         .stream()
         .map(delete ->
-            "s3a://" + delete.getBucketName() + "/" + delete.getKey())
+            "s3a://" + delete.bucket() + "/" + delete.key())
         .collect(Collectors.toSet());
 
     Assertions.assertThat(commits)

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingPartitionedTaskCommit.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/commit/staging/TestStagingPartitionedTaskCommit.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import org.apache.hadoop.util.Lists;
 import org.apache.hadoop.util.Sets;
 import org.assertj.core.api.Assertions;
@@ -35,6 +34,8 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathExistsException;
 import org.apache.hadoop.mapreduce.JobContext;
+
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 
 import static org.apache.hadoop.fs.s3a.commit.CommitConstants.*;
 import static org.apache.hadoop.test.LambdaTestUtils.intercept;
@@ -146,10 +147,10 @@ public class TestStagingPartitionedTaskCommit
   protected void verifyFilesCreated(
       final PartitionedStagingCommitter committer) {
     Set<String> files = Sets.newHashSet();
-    for (InitiateMultipartUploadRequest request :
+    for (CreateMultipartUploadRequest request :
         getMockResults().getRequests().values()) {
-      assertEquals(BUCKET, request.getBucketName());
-      files.add(request.getKey());
+      assertEquals(BUCKET, request.bucket());
+      files.add(request.key());
     }
     Assertions.assertThat(files)
         .describedAs("Should have the right number of uploads")

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
@@ -139,6 +140,10 @@ public class TestRequestFactory extends AbstractHadoopTestBase {
     }
   }
 
+  private <T extends AwsRequest> void a(AwsRequest.Builder request) {
+    // TODO: Implement for SDK v2 requests
+  }
+
   /**
    * Analyze the request, log the output, return the info.
    * @param request request.
@@ -166,10 +171,10 @@ public class TestRequestFactory extends AbstractHadoopTestBase {
    // a(factory.newCompleteMultipartUploadRequest(path, id,
    //     new ArrayList<>()));
    // a(factory.newCopyObjectRequest(path, path2, md));
-    a(factory.newDeleteObjectRequest(path));
-    a(factory.newBulkDeleteRequest(new ArrayList<>()));
+    a(factory.newDeleteObjectRequestBuilder(path));
+    a(factory.newBulkDeleteRequestBuilder(new ArrayList<>()));
    // a(factory.newDirectoryMarkerRequest(path));
-   // a(factory.newGetObjectRequest(path));
+    a(factory.newGetObjectRequestBuilder(path));
    // a(factory.newGetObjectMetadataRequest(path));
    // a(factory.newListMultipartUploadsRequest(path));
     //TODO: Commenting out for now, new request extends AwsRequest, this can be updated once all

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ILoadTestS3ABulkDeleteThrottling.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/scale/ILoadTestS3ABulkDeleteThrottling.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.assertj.core.api.Assertions;
@@ -51,6 +50,8 @@ import org.apache.hadoop.fs.s3a.S3ATestUtils;
 import org.apache.hadoop.fs.s3a.auth.delegation.Csvout;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
+
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import static org.apache.hadoop.fs.s3a.Constants.EXPERIMENTAL_AWS_INTERNAL_THROTTLING;
 import static org.apache.hadoop.fs.s3a.Constants.BULK_DELETE_PAGE_SIZE;
@@ -228,7 +229,7 @@ public class ILoadTestS3ABulkDeleteThrottling extends S3AScaleTestBase {
     Path basePath = path("testDeleteObjectThrottling");
     final S3AFileSystem fs = getFileSystem();
     final String base = fs.pathToKey(basePath);
-    final List<DeleteObjectsRequest.KeyVersion> fileList
+    final List<ObjectIdentifier> fileList
         = buildDeleteRequest(base, entries);
     final FileWriter out = new FileWriter(csvFile);
     Csvout csvout = new Csvout(out, "\t", "\n");
@@ -304,12 +305,12 @@ public class ILoadTestS3ABulkDeleteThrottling extends S3AScaleTestBase {
   }
 
 
-  private List<DeleteObjectsRequest.KeyVersion> buildDeleteRequest(
+  private List<ObjectIdentifier> buildDeleteRequest(
       String base, int count) {
-    List<DeleteObjectsRequest.KeyVersion> request = new ArrayList<>(count);
+    List<ObjectIdentifier> request = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
-      request.add(new DeleteObjectsRequest.KeyVersion(
-          String.format("%s/file-%04d", base, i)));
+      request.add(ObjectIdentifier.builder().key(
+          String.format("%s/file-%04d", base, i)).build());
     }
     return request;
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/MinimalOperationCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/test/MinimalOperationCallbacks.java
@@ -21,15 +21,14 @@ package org.apache.hadoop.fs.s3a.test;
 import java.io.IOException;
 import java.util.List;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.MultiObjectDeleteException;
-import com.amazonaws.services.s3.transfer.model.CopyResult;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.fs.s3a.MultiObjectDeleteException;
 import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.s3a.S3ALocatedFileStatus;
 import org.apache.hadoop.fs.s3a.S3AReadOpContext;
@@ -100,9 +99,9 @@ public class MinimalOperationCallbacks
 
   @Override
   public void removeKeys(
-          List<DeleteObjectsRequest.KeyVersion> keysToDelete,
+          List<ObjectIdentifier> keysToDelete,
           boolean deleteFakeDir)
-      throws MultiObjectDeleteException, AmazonClientException,
+      throws MultiObjectDeleteException, AwsServiceException,
              IOException {
   }
 


### PR DESCRIPTION
Key changes:
  * `ObjectIdentifier` replaces DeleteObjectsRequest.KeyVersion.
  * Bulk delete does not throw in SDK v2 if some deletion fail. A new `MultiObjectDeleteException` is created from the response object.
  * S3AFileSystem temporarily allows for setting mock instances of both v1 and v2 S3 clients.