### PR TITLE
Hadoop 18073 auditors

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -77,17 +77,12 @@ import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -103,6 +98,7 @@ import software.amazon.awssdk.transfer.s3.CopyRequest;
 import software.amazon.awssdk.transfer.s3.FileUpload;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 import software.amazon.awssdk.transfer.s3.UploadFileRequest;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -4269,13 +4265,11 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
 
     // TODO: Transfer manager currently only provides transfer listeners for upload,
     //  add progress listener for copy when this is supported.
-//    ProgressListener progressListener = progressEvent -> {
-//      switch (progressEvent.getEventType()) {
-//      case TRANSFER_PART_COMPLETED_EVENT:
+// TODO: Is the above still valid? Try to enable when logger issue is resolved.
+//    TransferListener progressListener = new TransferListener() {
+//      @Override
+//      public void transferComplete(Context.TransferComplete context) {
 //        incrementWriteOperations();
-//        break;
-//      default:
-//        break;
 //      }
 //    };
 
@@ -4319,7 +4313,13 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
           incrementStatistic(OBJECT_COPY_REQUESTS);
 
           Copy copy = transferManagerV2.copy(
-              CopyRequest.builder().copyObjectRequest(copyObjectRequestBuilder.build()).build());
+              CopyRequest.builder()
+                  .copyObjectRequest(copyObjectRequestBuilder.build())
+// TODO: Enable when logger issue is resolved.
+//                  .overrideConfiguration(c -> c
+//                      .addListener(getAuditManager().createTransferListener())
+//                      .addListener(progressListener))
+                  .build());
 
           CompletedCopy completedCopy = copy.completionFuture().join();
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java
@@ -967,7 +967,7 @@ public class S3AFileSystem extends FileSystem implements StreamCapabilities,
         .withPathStyleAccess(conf.getBoolean(PATH_STYLE_ACCESS, false))
         .withUserAgentSuffix(uaSuffix)
         .withRequesterPays(conf.getBoolean(ALLOW_REQUESTER_PAYS, DEFAULT_ALLOW_REQUESTER_PAYS))
-        .withRequestHandlers(auditManager.createRequestHandlers());
+        .withExecutionInterceptors(auditManager.createExecutionInterceptors());
 
     s3 = ReflectionUtils.newInstance(s3ClientFactoryClass, conf)
         .createS3Client(getUri(),

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1950,7 +1950,7 @@ public final class S3AUtils {
   private static final String BYTES_PREFIX = "bytes=";
 
   public static Optional<Pair<Long, Long>> parseRange(String rangeHeader) {
-    // TODO:WiP: Surely, there is a better way.
+    // TODO: Surely, there is a better way.
     if (rangeHeader != null && rangeHeader.startsWith(BYTES_PREFIX)) {
       String[] values = rangeHeader.substring("bytes=".length()).split("-");
       if (values.length == 2) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -29,10 +29,10 @@ import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.retry.RetryUtils;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.MultiObjectDeleteException;
-import org.apache.hadoop.classification.VisibleForTesting;
-import org.apache.hadoop.util.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -49,6 +49,7 @@ import org.apache.hadoop.fs.s3a.impl.V2Migration;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 import org.apache.hadoop.net.ConnectTimeoutException;
 import org.apache.hadoop.security.ProviderUtils;
+import org.apache.hadoop.util.Preconditions;
 import org.apache.hadoop.util.VersionInfo;
 
 import org.apache.hadoop.util.Lists;
@@ -1944,5 +1945,23 @@ public final class S3AUtils {
    */
   public static String formatRange(long rangeStart, long rangeEnd) {
     return String.format("bytes=%d-%d", rangeStart, rangeEnd);
+  }
+
+  private static final String BYTES_PREFIX = "bytes=";
+
+  public static Optional<Pair<Long, Long>> parseRange(String rangeHeader) {
+    // TODO:WiP: Surely, there is a better way.
+    if (rangeHeader != null && rangeHeader.startsWith(BYTES_PREFIX)) {
+      String[] values = rangeHeader.substring("bytes=".length()).split("-");
+      if (values.length == 2) {
+        try {
+          Long start = Long.parseUnsignedLong(values[0]);
+          Long end = Long.parseUnsignedLong(values[0]);
+          return Optional.of(Pair.of(start, end));
+        } catch(NumberFormatException e) {
+        }
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -1946,22 +1946,4 @@ public final class S3AUtils {
   public static String formatRange(long rangeStart, long rangeEnd) {
     return String.format("bytes=%d-%d", rangeStart, rangeEnd);
   }
-
-  private static final String BYTES_PREFIX = "bytes=";
-
-  public static Optional<Pair<Long, Long>> parseRange(String rangeHeader) {
-    // TODO: Surely, there is a better way.
-    if (rangeHeader != null && rangeHeader.startsWith(BYTES_PREFIX)) {
-      String[] values = rangeHeader.substring("bytes=".length()).split("-");
-      if (values.length == 2) {
-        try {
-          Long start = Long.parseUnsignedLong(values[0]);
-          Long end = Long.parseUnsignedLong(values[0]);
-          return Optional.of(Pair.of(start, end));
-        } catch(NumberFormatException e) {
-        }
-      }
-    }
-    return Optional.empty();
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -26,14 +26,15 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.monitoring.MonitoringListener;
 import com.amazonaws.services.s3.AmazonS3;
-import software.amazon.awssdk.services.s3.S3Client;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.s3a.statistics.StatisticsFromAwsSdk;
+
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_ENDPOINT;
 
@@ -122,9 +123,9 @@ public interface S3ClientFactory {
     private boolean requesterPays;
 
     /**
-     * Request handlers; used for auditing, X-Ray etc.
-     */
-    private List<RequestHandler2> requestHandlers;
+     * Execution interceptors; used for auditing, X-Ray etc.
+     * */
+    private List<ExecutionInterceptor> executionInterceptors;
 
     /**
      * Suffix to UA.
@@ -138,22 +139,22 @@ public interface S3ClientFactory {
     private URI pathUri;
 
     /**
-     * List of request handlers to include in the chain
-     * of request execution in the SDK.
-     * @return the handler list
+     * List of execution interceptors to include in the chain
+     * of interceptors in the SDK.
+     * @return the interceptors list
      */
-    public List<RequestHandler2> getRequestHandlers() {
-      return requestHandlers;
+    public List<ExecutionInterceptor> getExecutionInterceptors() {
+      return executionInterceptors;
     }
 
     /**
-     * List of request handlers.
-     * @param handlers handler list.
+     * List of execution interceptors.
+     * @param interceptors interceptors list.
      * @return this object
      */
-    public S3ClientCreationParameters withRequestHandlers(
-        @Nullable final List<RequestHandler2> handlers) {
-      requestHandlers = handlers;
+    public S3ClientCreationParameters withExecutionInterceptors(
+        @Nullable final List<ExecutionInterceptor> interceptors) {
+      executionInterceptors = interceptors;
       return this;
     }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/api/RequestFactory.java
@@ -22,9 +22,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-import com.amazonaws.services.s3.model.ListNextBatchOfObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.SelectObjectContentRequest;
 
@@ -80,13 +77,6 @@ public interface RequestFactory {
    * @return an ACL, if any
    */
   ObjectCannedACL getCannedACL();
-
-  /**
-   * Create the AWS SDK structure used to configure SSE,
-   * if the encryption secrets contain the information/settings for this.
-   * @return an optional set of KMS Key settings
-   */
-  Optional<SSEAwsKeyManagementParams> generateSSEAwsKeyParams();
 
   /**
    * Create the SSE-C structure for the AWS SDK, if the encryption secrets
@@ -241,16 +231,6 @@ public interface RequestFactory {
   ListObjectsRequest.Builder newListObjectsV1RequestBuilder(String key,
       String delimiter,
       int maxKeys);
-
-  /**
-   * Create the next V1 page list request, following
-   * on from the previous response.
-   * @param prev previous response
-   * @return the request
-   */
-
-  ListNextBatchOfObjectsRequest newListNextBatchOfObjectsRequest(
-      ObjectListing prev);
 
   /**
    * Create a V2 list request builder.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSAuditEventCallbacks.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSAuditEventCallbacks.java
@@ -18,13 +18,8 @@
 
 package org.apache.hadoop.fs.s3a.audit;
 
-import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.Request;
-import com.amazonaws.Response;
-import com.amazonaws.SdkBaseException;
-import com.amazonaws.handlers.HandlerAfterAttemptContext;
-import com.amazonaws.handlers.HandlerBeforeAttemptContext;
-import com.amazonaws.http.HttpResponse;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 import org.apache.hadoop.fs.s3a.Retries;
 
@@ -37,10 +32,10 @@ import org.apache.hadoop.fs.s3a.Retries;
  * detect this and raise an exception.
  *
  * Look at the documentation for
- * {@code com.amazonaws.handlers.IRequestHandler2} for details
+ * {@code ExecutionInterceptor} for details
  * on the callbacks.
  */
-public interface AWSAuditEventCallbacks {
+public interface AWSAuditEventCallbacks extends ExecutionInterceptor {
 
   /**
    * Return a span ID which must be unique for all spans within
@@ -66,95 +61,8 @@ public interface AWSAuditEventCallbacks {
    * It is not invoked on any AWS requests created in the SDK.
    * Avoid raising exceptions or talking to any remote service;
    * this callback is for annotation rather than validation.
-   * @param request request request.
-   * @param <T> type of request
-   * @return the request, possibly modified.
+   * @param builder the request builder.
    */
-  default <T extends AmazonWebServiceRequest> T requestCreated(T request) {
-    return request;
-  }
+  default void requestCreated(SdkRequest.Builder builder) {}
 
-  /**
-   * Preflight preparation of AWS request.
-   * @param request request
-   * @param <T> type of request
-   * @return an updated request.
-   * @throws AuditFailureException for generic audit failures
-   * @throws SdkBaseException for other reasons.
-   */
-  @Retries.OnceRaw
-  default <T extends AmazonWebServiceRequest> T beforeExecution(T request)
-      throws AuditFailureException, SdkBaseException {
-    return request;
-  }
-
-  /**
-   * Callback after S3 responded to a request.
-   * @param request request
-   * @param response response.
-   * @throws AuditFailureException for generic audit failures
-   * @throws SdkBaseException for other reasons.
-   */
-  default void afterResponse(Request<?> request,
-      Response<?> response)
-      throws AuditFailureException, SdkBaseException {
-  }
-
-  /**
-   * Callback after a request resulted in an error.
-   * @param request request
-   * @param response response.
-   * @param exception exception raised.
-   * @throws AuditFailureException for generic audit failures
-   * @throws SdkBaseException for other reasons.
-   */
-  default void afterError(Request<?> request,
-      Response<?> response,
-      Exception exception)
-      throws AuditFailureException, SdkBaseException {
-  }
-
-  /**
-   * Request before marshalling.
-   * @param request request
-   * @return possibly modified request.
-   */
-  default AmazonWebServiceRequest beforeMarshalling(
-      AmazonWebServiceRequest request) {
-    return request;
-  }
-
-  /**
-   * Request before marshalling.
-   * @param request request
-   */
-  default void beforeRequest(Request<?> request) {
-  }
-
-  /**
-   * Before any attempt is made.
-   * @param context full context, including the request.
-   */
-  default void beforeAttempt(HandlerBeforeAttemptContext context) {
-  }
-
-  /**
-   * After any attempt is made.
-   * @param context full context, including the request.
-   */
-  default void afterAttempt(
-      HandlerAfterAttemptContext context) {
-  }
-
-  /**
-   * Before unmarshalling the response.
-   * @param request request made.
-   * @param httpResponse response received
-   * @return updated response.
-   */
-  default HttpResponse beforeUnmarshalling(
-      final Request<?> request,
-      final HttpResponse httpResponse) {
-    return httpResponse;
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
@@ -21,23 +21,26 @@ package org.apache.hadoop.fs.s3a.audit;
 import java.util.List;
 
 import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CopyPartRequest;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.GetBucketLocationRequest;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
-import com.amazonaws.services.s3.model.ListNextBatchOfObjectsRequest;
-import com.amazonaws.services.s3.model.ListObjectsRequest;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.SelectObjectContentRequest;
-import com.amazonaws.services.s3.model.UploadPartRequest;
+
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListMultipartUploadsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+
+import org.apache.hadoop.fs.s3a.S3AUtils;
 
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_GET_REQUEST;
 import static org.apache.hadoop.fs.statistics.StoreStatisticNames.ACTION_HTTP_HEAD_REQUEST;
@@ -66,100 +69,104 @@ public class AWSRequestAnalyzer {
    * @return information about the request.
    * @param <T> type of request.
    */
-  public <T extends AmazonWebServiceRequest> RequestInfo analyze(T request) {
+  public RequestInfo analyze(SdkRequest request) {
 
     // this is where Scala's case statement would massively
     // simplify life.
     // Please Keep in Alphabetical Order.
     if (request instanceof AbortMultipartUploadRequest) {
       return writing(MULTIPART_UPLOAD_ABORTED,
-          ((AbortMultipartUploadRequest) request).getKey(),
+          ((AbortMultipartUploadRequest) request).key(),
           0);
     } else if (request instanceof CompleteMultipartUploadRequest) {
       CompleteMultipartUploadRequest r
           = (CompleteMultipartUploadRequest) request;
       return writing(MULTIPART_UPLOAD_COMPLETED,
-          r.getKey(),
-          r.getPartETags().size());
+          r.key(),
+          r.multipartUpload().parts().size());
     } else if (request instanceof DeleteObjectRequest) {
       // DeleteObject: single object
       return writing(OBJECT_DELETE_REQUEST,
-          ((DeleteObjectRequest) request).getKey(),
+          ((DeleteObjectRequest) request).key(),
           1);
     } else if (request instanceof DeleteObjectsRequest) {
       // DeleteObjects: bulk delete
       // use first key as the path
       DeleteObjectsRequest r = (DeleteObjectsRequest) request;
-      List<DeleteObjectsRequest.KeyVersion> keys
-          = r.getKeys();
+      List<ObjectIdentifier> objectIdentifiers
+          = r.delete().objects();
       return writing(OBJECT_BULK_DELETE_REQUEST,
-          keys.isEmpty() ? null : keys.get(0).getKey(),
-          keys.size());
+          objectIdentifiers.isEmpty() ? null : objectIdentifiers.get(0).key(),
+          objectIdentifiers.size());
     } else if (request instanceof GetBucketLocationRequest) {
       GetBucketLocationRequest r = (GetBucketLocationRequest) request;
       return reading(STORE_EXISTS_PROBE,
-          r.getBucketName(),
+          r.bucket(),
           0);
-    } else if (request instanceof GetObjectMetadataRequest) {
+    } else if (request instanceof HeadObjectRequest) {
       return reading(ACTION_HTTP_HEAD_REQUEST,
-          ((GetObjectMetadataRequest) request).getKey(), 0);
+          ((HeadObjectRequest) request).key(), 0);
     } else if (request instanceof GetObjectRequest) {
       GetObjectRequest r = (GetObjectRequest) request;
-      long[] range = r.getRange();
-      long size = range == null
-          ? -1
-          : range[1] - range[0];
+      long size = S3AUtils.parseRange(r.range())
+          .map(range -> range.getRight() - range.getLeft())
+          .orElse(Long.valueOf(-1));
       return reading(ACTION_HTTP_GET_REQUEST,
-          r.getKey(),
+          r.key(),
           size);
-    } else if (request instanceof InitiateMultipartUploadRequest) {
+    } else if (request instanceof CreateMultipartUploadRequest) {
       return writing(MULTIPART_UPLOAD_STARTED,
-          ((InitiateMultipartUploadRequest) request).getKey(),
+          ((CreateMultipartUploadRequest) request).key(),
           0);
     } else if (request instanceof ListMultipartUploadsRequest) {
       ListMultipartUploadsRequest r
           = (ListMultipartUploadsRequest) request;
       return reading(MULTIPART_UPLOAD_LIST,
-          r.getPrefix(),
-          r.getMaxUploads());
+          r.prefix(),
+          r.maxUploads());
     } else if (request instanceof ListObjectsRequest) {
       ListObjectsRequest r = (ListObjectsRequest) request;
       return reading(OBJECT_LIST_REQUEST,
-          r.getPrefix(),
-          r.getMaxKeys());
-    } else if (request instanceof ListNextBatchOfObjectsRequest) {
-      ListNextBatchOfObjectsRequest r = (ListNextBatchOfObjectsRequest) request;
-      ObjectListing l = r.getPreviousObjectListing();
-      String prefix = "";
-      int size = 0;
-      if (l != null) {
-        prefix = l.getPrefix();
-        size = l.getMaxKeys();
-      }
-      return reading(OBJECT_LIST_REQUEST,
-          prefix,
-          size);
+          r.prefix(),
+          r.maxKeys());
     } else if (request instanceof ListObjectsV2Request) {
       ListObjectsV2Request r = (ListObjectsV2Request) request;
       return reading(OBJECT_LIST_REQUEST,
-          r.getPrefix(),
-          r.getMaxKeys());
+          r.prefix(),
+          r.maxKeys());
     } else if (request instanceof PutObjectRequest) {
       PutObjectRequest r = (PutObjectRequest) request;
       return writing(OBJECT_PUT_REQUEST,
-          r.getKey(),
+          r.key(),
           0);
-    } else if (request instanceof SelectObjectContentRequest) {
+    } else if (request instanceof UploadPartRequest) {
+      UploadPartRequest r = (UploadPartRequest) request;
+      return writing(MULTIPART_UPLOAD_PART_PUT,
+          r.key(),
+          r.contentLength());
+    }
+    // no explicit support, return classname
+    return writing(request.getClass().getName(), null, 0);
+  }
+
+  /**
+   * Given an AWS request, try to analyze it to operation,
+   * read/write and path.
+   * @param request request.
+   * @return information about the request.
+   * @param <T> type of request.
+   */
+  public <T extends AmazonWebServiceRequest> RequestInfo analyze(T request) {
+
+    // this is where Scala's case statement would massively
+    // simplify life.
+    // Please Keep in Alphabetical Order.
+    if (request instanceof SelectObjectContentRequest) {
       SelectObjectContentRequest r =
           (SelectObjectContentRequest) request;
       return reading(OBJECT_SELECT_REQUESTS,
           r.getKey(),
           1);
-    } else if (request instanceof UploadPartRequest) {
-      UploadPartRequest r = (UploadPartRequest) request;
-      return writing(MULTIPART_UPLOAD_PART_PUT,
-          r.getKey(),
-          r.getPartSize());
     }
     // no explicit support, return classname
     return writing(request.getClass().getName(), null, 0);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AWSRequestAnalyzer.java
@@ -67,7 +67,6 @@ public class AWSRequestAnalyzer {
    * read/write and path.
    * @param request request.
    * @return information about the request.
-   * @param <T> type of request.
    */
   public RequestInfo analyze(SdkRequest request) {
 
@@ -84,6 +83,10 @@ public class AWSRequestAnalyzer {
       return writing(MULTIPART_UPLOAD_COMPLETED,
           r.key(),
           r.multipartUpload().parts().size());
+    } else if (request instanceof CreateMultipartUploadRequest) {
+      return writing(MULTIPART_UPLOAD_STARTED,
+          ((CreateMultipartUploadRequest) request).key(),
+          0);
     } else if (request instanceof DeleteObjectRequest) {
       // DeleteObject: single object
       return writing(OBJECT_DELETE_REQUEST,
@@ -103,9 +106,6 @@ public class AWSRequestAnalyzer {
       return reading(STORE_EXISTS_PROBE,
           r.bucket(),
           0);
-    } else if (request instanceof HeadObjectRequest) {
-      return reading(ACTION_HTTP_HEAD_REQUEST,
-          ((HeadObjectRequest) request).key(), 0);
     } else if (request instanceof GetObjectRequest) {
       GetObjectRequest r = (GetObjectRequest) request;
       long size = S3AUtils.parseRange(r.range())
@@ -114,10 +114,9 @@ public class AWSRequestAnalyzer {
       return reading(ACTION_HTTP_GET_REQUEST,
           r.key(),
           size);
-    } else if (request instanceof CreateMultipartUploadRequest) {
-      return writing(MULTIPART_UPLOAD_STARTED,
-          ((CreateMultipartUploadRequest) request).key(),
-          0);
+    } else if (request instanceof HeadObjectRequest) {
+      return reading(ACTION_HTTP_HEAD_REQUEST,
+          ((HeadObjectRequest) request).key(), 0);
     } else if (request instanceof ListMultipartUploadsRequest) {
       ListMultipartUploadsRequest r
           = (ListMultipartUploadsRequest) request;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditIntegration.java
@@ -122,9 +122,8 @@ public final class AuditIntegration {
   }
 
   /**
-   * Get the span from a handler context.
-   * @param request request
-   * @param <T> type of request.
+   * Get the span from the execution attributes.
+   * @param executionAttributes the execution attributes
    * @return the span callbacks or null
    */
   public static AuditSpanS3A
@@ -133,10 +132,9 @@ public final class AuditIntegration {
   }
 
   /**
-   * Attach a span to a handler context.
-   * @param request request
+   * Attach a span to the execution attributes.
+   * @param executionAttributes the execution attributes
    * @param span span to attach
-   * @param <T> type of request.
    */
   public static void attachSpanToRequest(
       final ExecutionAttributes executionAttributes,

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditIntegration.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
-import com.amazonaws.HandlerContextAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,10 +31,12 @@ import org.apache.hadoop.fs.s3a.audit.impl.LoggingAuditor;
 import org.apache.hadoop.fs.s3a.audit.impl.NoopAuditManagerS3A;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_ENABLED;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_ENABLED_DEFAULT;
-import static org.apache.hadoop.fs.s3a.audit.impl.S3AInternalAuditConstants.AUDIT_SPAN_HANDLER_CONTEXT;
+import static org.apache.hadoop.fs.s3a.audit.impl.S3AInternalAuditConstants.AUDIT_SPAN_EXECUTION_ATTRIBUTE;
 
 /**
  * Support for integrating auditing within the S3A code.
@@ -126,9 +127,9 @@ public final class AuditIntegration {
    * @param <T> type of request.
    * @return the span callbacks or null
    */
-  public static <T extends HandlerContextAware> AWSAuditEventCallbacks
-      retrieveAttachedSpan(final T request) {
-    return request.getHandlerContext(AUDIT_SPAN_HANDLER_CONTEXT);
+  public static AuditSpanS3A
+      retrieveAttachedSpan(final ExecutionAttributes executionAttributes) {
+    return executionAttributes.getAttribute(AUDIT_SPAN_EXECUTION_ATTRIBUTE);
   }
 
   /**
@@ -137,9 +138,10 @@ public final class AuditIntegration {
    * @param span span to attach
    * @param <T> type of request.
    */
-  public static <T extends HandlerContextAware> void attachSpanToRequest(
-      final T request, final AWSAuditEventCallbacks span) {
-    request.addHandlerContext(AUDIT_SPAN_HANDLER_CONTEXT, span);
+  public static void attachSpanToRequest(
+      final ExecutionAttributes executionAttributes,
+      final AuditSpanS3A span) {
+    executionAttributes.putAttribute(AUDIT_SPAN_EXECUTION_ATTRIBUTE, span);
   }
 
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditManagerS3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditManagerS3A.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.s3a.audit;
 import java.io.IOException;
 import java.util.List;
 
-import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -31,6 +30,9 @@ import org.apache.hadoop.fs.s3a.S3AFileStatus;
 import org.apache.hadoop.fs.store.audit.ActiveThreadSpanSource;
 import org.apache.hadoop.fs.store.audit.AuditSpanSource;
 import org.apache.hadoop.service.Service;
+
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 /**
  * Interface for Audit Managers auditing operations through the
@@ -56,12 +58,12 @@ public interface AuditManagerS3A extends Service,
   OperationAuditor getAuditor();
 
   /**
-   * Create the request handler(s) for this audit service.
-   * The list returned is mutable; new handlers may be added.
-   * @return list of handlers for the SDK.
+   * Create the execution interceptor(s) for this audit service.
+   * The list returned is mutable; new interceptors may be added.
+   * @return list of interceptors for the SDK.
    * @throws IOException failure.
    */
-  List<RequestHandler2> createRequestHandlers() throws IOException;
+  List<ExecutionInterceptor> createExecutionInterceptors() throws IOException;
 
   /**
    * Return a transfer state change callback which

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditManagerS3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/AuditManagerS3A.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.fs.s3a.audit;
 import java.io.IOException;
 import java.util.List;
 
-import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -31,8 +29,8 @@ import org.apache.hadoop.fs.store.audit.ActiveThreadSpanSource;
 import org.apache.hadoop.fs.store.audit.AuditSpanSource;
 import org.apache.hadoop.service.Service;
 
-import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 /**
  * Interface for Audit Managers auditing operations through the
@@ -66,16 +64,16 @@ public interface AuditManagerS3A extends Service,
   List<ExecutionInterceptor> createExecutionInterceptors() throws IOException;
 
   /**
-   * Return a transfer state change callback which
+   * Return a transfer callback which
    * fixes the active span context to be that in which
-   * the state change listener was created.
+   * the transfer listener was created.
    * This can be used to audit the creation of the multipart
    * upload initiation request which the transfer manager
    * makes when a file to be copied is split up.
    * This must be invoked/used within the active span.
-   * @return a state change listener.
+   * @return a transfer listener.
    */
-  TransferStateChangeListener createStateChangeListener();
+  TransferListener createTransferListener();
 
   /**
    * Check for permission to access a path.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/S3AAuditConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/S3AAuditConstants.java
@@ -66,12 +66,12 @@ public final class S3AAuditConstants {
       "org.apache.hadoop.fs.s3a.audit.impl.NoopAuditor";
 
   /**
-   * List of extra AWS SDK request handlers: {@value}.
+   * List of extra AWS SDK execution interceptors: {@value}.
    * These are added to the SDK request chain <i>after</i>
    * any audit service.
    */
-  public static final String AUDIT_REQUEST_HANDLERS =
-      "fs.s3a.audit.request.handlers";
+  public static final String AUDIT_EXECUTION_INTERCEPTORS =
+      "fs.s3a.audit.execution.interceptors";
 
   /**
    * Should operations outside spans be rejected?

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/S3AAuditConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/S3AAuditConstants.java
@@ -66,6 +66,13 @@ public final class S3AAuditConstants {
       "org.apache.hadoop.fs.s3a.audit.impl.NoopAuditor";
 
   /**
+   * Deprecated list of extra AWS SDK request handlers: {@value}.
+   * Use {@link #AUDIT_EXECUTION_INTERCEPTORS} instead.
+   */
+  public static final String AUDIT_REQUEST_HANDLERS =
+      "fs.s3a.audit.request.handlers";
+
+  /**
    * List of extra AWS SDK execution interceptors: {@value}.
    * These are added to the SDK request chain <i>after</i>
    * any audit service.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/ActiveAuditManagerS3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/ActiveAuditManagerS3A.java
@@ -405,7 +405,7 @@ public final class ActiveAuditManagerS3A
     List<ExecutionInterceptor> executionInterceptors = new ArrayList<>();
     executionInterceptors.add(this);
 
-    final Class<?>[] handlers = getConfig().getClasses(AUDIT_REQUEST_HANDLERS);
+    final String handlers = getConfig().get(AUDIT_REQUEST_HANDLERS);
     if (handlers != null) {
       V2Migration.v1RequestHandlersUsed();
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/ActiveAuditManagerS3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/ActiveAuditManagerS3A.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +58,7 @@ import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.http.SdkHttpRequest;
 import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.s3a.Statistic.AUDIT_FAILURE;
@@ -422,9 +422,14 @@ public final class ActiveAuditManagerS3A
   }
 
   @Override
-  public TransferStateChangeListener createStateChangeListener() {
+  public TransferListener createTransferListener() {
     final WrappingAuditSpan span = activeSpan();
-    return (transfer, state) -> switchToActiveSpan(span);
+    return new TransferListener() {
+      @Override
+      public void transferInitiated(Context.TransferInitiated context) {
+        switchToActiveSpan(span);
+      }
+    };
   }
 
   @Override

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/LoggingAuditor.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.AmazonWebServiceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +36,11 @@ import org.apache.hadoop.fs.s3a.audit.AuditFailureException;
 import org.apache.hadoop.fs.s3a.audit.AuditSpanS3A;
 import org.apache.hadoop.fs.store.audit.HttpReferrerAuditHeader;
 import org.apache.hadoop.security.UserGroupInformation;
+
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.http.SdkHttpRequest;
 
 import static org.apache.hadoop.fs.audit.AuditConstants.PARAM_FILESYSTEM_ID;
 import static org.apache.hadoop.fs.audit.AuditConstants.PARAM_PRINCIPAL;
@@ -300,38 +304,47 @@ public class LoggingAuditor
       referrer.set(key, value);
     }
 
+
+
     /**
-     * Before execution, the logging auditor always builds
-     * the referrer header, saves to the outer class
-     * (where {@link #getLastHeader()} can retrieve it,
+     * Before transmitting a request, the logging auditor
+     * always builds the referrer header, saves to the outer
+     * class (where {@link #getLastHeader()} can retrieve it,
      * and logs at debug.
      * If configured to add the header to the S3 logs, it will
      * be set as the HTTP referrer.
-     * @param request request
-     * @param <T> type of request.
-     * @return the request with any extra headers.
+     * @param context The current state of the execution,
+     *                including the SDK and current HTTP request.
+     * @param executionAttributes A mutable set of attributes scoped
+     *                            to one specific request/response
+     *                            cycle that can be used to give data
+     *                            to future lifecycle methods.
+     * @return The potentially-modified HTTP request that should be
+     *          sent to the service. Must not be null.
      */
     @Override
-    public <T extends AmazonWebServiceRequest> T beforeExecution(
-        final T request) {
+    public SdkHttpRequest modifyHttpRequest(Context.ModifyHttpRequest context,
+        ExecutionAttributes executionAttributes) {
+      SdkHttpRequest httpRequest = context.httpRequest();
       // build the referrer header
       final String header = referrer.buildHttpReferrer();
       // update the outer class's field.
       setLastHeader(header);
       if (headerEnabled) {
         // add the referrer header
-        request.putCustomRequestHeader(HEADER_REFERRER,
-            header);
+        httpRequest = httpRequest.toBuilder()
+            .appendHeader(HEADER_REFERRER, header)
+            .build();
       }
       if (LOG.isDebugEnabled()) {
         LOG.debug("[{}] {} Executing {} with {}; {}",
             currentThreadID(),
             getSpanId(),
             getOperationName(),
-            analyzer.analyze(request),
+            analyzer.analyze(context.request()),
             header);
       }
-      return request;
+      return httpRequest;
     }
 
     @Override
@@ -386,15 +399,13 @@ public class LoggingAuditor
     }
 
     @Override
-    public <T extends AmazonWebServiceRequest> T requestCreated(
-        final T request) {
+    public void requestCreated(final SdkRequest.Builder builder) {
       String error = "Creating a request outside an audit span "
-          + analyzer.analyze(request);
+          + analyzer.analyze(builder.build());
       LOG.info(error);
       if (LOG.isDebugEnabled()) {
         LOG.debug(error, new AuditFailureException("unaudited"));
       }
-      return request;
     }
 
     /**
@@ -402,20 +413,22 @@ public class LoggingAuditor
      * increment the failure count.
      * Some requests (e.g. copy part) are not expected in spans due
      * to how they are executed; these do not trigger failures.
-     * @param request request
-     * @param <T> type of request
-     * @return an updated request.
-     * @throws AuditFailureException if failure is enabled.
+     * @param context The current state of the execution, including
+     *                the unmodified SDK request from the service
+     *                client call.
+     * @param executionAttributes A mutable set of attributes scoped
+     *                            to one specific request/response
+     *                            cycle that can be used to give data
+     *                            to future lifecycle methods.
      */
     @Override
-    public <T extends AmazonWebServiceRequest> T beforeExecution(
-        final T request) {
-
+    public void beforeExecution(Context.BeforeExecution context,
+        ExecutionAttributes executionAttributes) {
       String error = "executing a request outside an audit span "
-          + analyzer.analyze(request);
+          + analyzer.analyze(context.request());
       final String unaudited = getSpanId() + " "
           + UNAUDITED_OPERATION + " " + error;
-      if (isRequestNotAlwaysInSpan(request)) {
+      if (isRequestNotAlwaysInSpan(context.request())) {
         // can get by auditing during a copy, so don't overreact
         LOG.debug(unaudited);
       } else {
@@ -426,7 +439,7 @@ public class LoggingAuditor
         }
       }
       // now hand off to the superclass for its normal preparation
-      return super.beforeExecution(request);
+      super.beforeExecution(context, executionAttributes);
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/NoopAuditManagerS3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/NoopAuditManagerS3A.java
@@ -24,9 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import com.amazonaws.services.s3.transfer.Transfer;
-import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -39,6 +36,7 @@ import org.apache.hadoop.fs.s3a.audit.OperationAuditorOptions;
 import org.apache.hadoop.service.CompositeService;
 
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.transfer.s3.progress.TransferListener;
 
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
@@ -127,12 +125,8 @@ public class NoopAuditManagerS3A extends CompositeService
   }
 
   @Override
-  public TransferStateChangeListener createStateChangeListener() {
-    return new TransferStateChangeListener() {
-      public void transferStateChanged(final Transfer transfer,
-          final Transfer.TransferState state) {
-      }
-    };
+  public TransferListener createTransferListener() {
+    return new TransferListener() {};
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/NoopAuditManagerS3A.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/NoopAuditManagerS3A.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.services.s3.transfer.Transfer;
 import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 
@@ -38,6 +37,8 @@ import org.apache.hadoop.fs.s3a.audit.AuditSpanS3A;
 import org.apache.hadoop.fs.s3a.audit.OperationAuditor;
 import org.apache.hadoop.fs.s3a.audit.OperationAuditorOptions;
 import org.apache.hadoop.service.CompositeService;
+
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 import static org.apache.hadoop.fs.statistics.impl.IOStatisticsBinding.iostatisticsStore;
 
@@ -121,7 +122,7 @@ public class NoopAuditManagerS3A extends CompositeService
   }
 
   @Override
-  public List<RequestHandler2> createRequestHandlers() throws IOException {
+  public List<ExecutionInterceptor> createExecutionInterceptors() throws IOException {
     return new ArrayList<>();
   }
 

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/S3AInternalAuditConstants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/audit/impl/S3AInternalAuditConstants.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.fs.s3a.audit.impl;
 
-import com.amazonaws.handlers.HandlerContextKey;
+import software.amazon.awssdk.core.interceptor.ExecutionAttribute;
 
 import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.fs.s3a.audit.AWSAuditEventCallbacks;
+import org.apache.hadoop.fs.s3a.audit.AuditSpanS3A;
 
 /**
  * Internal constants; not intended for public use, or
@@ -34,11 +34,11 @@ public final class S3AInternalAuditConstants {
   }
 
   /**
-   * Handler key for audit span callbacks.
-   * This is used to bind the handler in the AWS code.
+   * Exceution attribute for audit span callbacks.
+   * This is used to retrieve the span in the AWS code.
    */
-  public static final HandlerContextKey<AWSAuditEventCallbacks>
-      AUDIT_SPAN_HANDLER_CONTEXT =
-      new HandlerContextKey<>(
-          "org.apache.hadoop.fs.s3a.audit.AWSAuditEventCallbacks");
+  public static final ExecutionAttribute<AuditSpanS3A>
+      AUDIT_SPAN_EXECUTION_ATTRIBUTE =
+      new ExecutionAttribute<>(
+          "org.apache.hadoop.fs.s3a.audit.AuditSpanS3A");
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -536,7 +536,7 @@ public class RequestFactoryImpl implements RequestFactory {
     request.setKey(key);
     generateSSECustomerKey().ifPresent(request::setSSECustomerKey);
 
-    // TODO:WiP: revert when select is upgraded to v2
+    // TODO: revert when select is upgraded to v2
     // return prepareRequest(requestBuilder);
     return request;
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/RequestFactoryImpl.java
@@ -26,9 +26,6 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.services.s3.model.ListNextBatchOfObjectsRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.SelectObjectContentRequest;
 import org.apache.hadoop.util.Preconditions;
@@ -36,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
@@ -84,8 +82,8 @@ import static org.apache.hadoop.util.Preconditions.checkNotNull;
  * This is where audit span information is added to the requests,
  * until it is done in the AWS SDK itself.
  *
- * All created requests will be passed through
- * {@link PrepareRequest#prepareRequest(AmazonWebServiceRequest)} before
+ * All created request builders will be passed to
+ * {@link PrepareRequest#prepareRequest(SdkRequest.Builder)} before
  * being returned to the caller.
  */
 public class RequestFactoryImpl implements RequestFactory {
@@ -146,24 +144,14 @@ public class RequestFactoryImpl implements RequestFactory {
 
   /**
    * Preflight preparation of AWS request.
-   * @param <T> web service request
-   * @return prepared entry.
+   * @param <T> web service request builder
+   * @return prepared builder.
    */
   @Retries.OnceRaw
-  private <T extends AmazonWebServiceRequest> T prepareRequest(T t) {
-    return requestPreparer != null
-        ? requestPreparer.prepareRequest(t)
-        : t;
-  }
-
-  /**
-   * Preflight preparation of V2 AWS request.
-   * @param <T> web service request
-   * @return prepared entry.
-   */
-  // TODO: Currently this is a NOOP, will be completed separately as part of auditor work.
-  @Retries.OnceRaw
-  private <T extends AwsRequest.Builder> T prepareV2Request(T t) {
+  private <T extends SdkRequest.Builder> T prepareRequest(T t) {
+    if (requestPreparer != null) {
+      requestPreparer.prepareRequest(t);
+    }
     return t;
   }
 
@@ -185,25 +173,12 @@ public class RequestFactoryImpl implements RequestFactory {
   }
 
   /**
-   * Create the AWS SDK structure used to configure SSE,
-   * if the encryption secrets contain the information/settings for this.
-   * @return an optional set of KMS Key settings
-   */
-  // TODO: This method can be removed during getObject work, as the key now comes directly from
-  //  EncryptionSecretOperations.getSSEAwsKMSKey.
-  @Override
-  public Optional<SSEAwsKeyManagementParams> generateSSEAwsKeyParams() {
-    return EncryptionSecretOperations.createSSEAwsKeyManagementParams(
-        encryptionSecrets);
-  }
-
-  /**
    * Create the SSE-C structure for the AWS SDK, if the encryption secrets
    * contain the information/settings for this.
    * This will contain a secret extracted from the bucket/configuration.
    * @return an optional customer key.
    */
-  // TODO: This method can be removed during getObject work, as the key now comes directly from
+  // TODO: This method can be removed during SelectObject work, as the key now comes directly from
   //  EncryptionSecretOperations.getSSECustomerKey.
   @Override
   public Optional<SSECustomerKey> generateSSECustomerKey() {
@@ -288,7 +263,7 @@ public class RequestFactoryImpl implements RequestFactory {
     copyObjectRequestBuilder.destinationBucket(getBucket())
         .destinationKey(dstKey).sourceBucket(getBucket()).sourceKey(srcKey);
 
-    return prepareV2Request(copyObjectRequestBuilder);
+    return prepareRequest(copyObjectRequestBuilder);
   }
 
   /**
@@ -350,7 +325,7 @@ public class RequestFactoryImpl implements RequestFactory {
       putObjectRequestBuilder.storageClass(storageClass);
     }
 
-    return prepareV2Request(putObjectRequestBuilder);
+    return prepareRequest(putObjectRequestBuilder);
   }
 
   private PutObjectRequest.Builder buildPutObjectRequest(long length, boolean isDirectoryMarker) {
@@ -405,7 +380,7 @@ public class RequestFactoryImpl implements RequestFactory {
 
     putEncryptionParameters(putObjectRequestBuilder);
 
-    return prepareV2Request(putObjectRequestBuilder);
+    return prepareRequest(putObjectRequestBuilder);
   }
 
   @Override
@@ -418,7 +393,7 @@ public class RequestFactoryImpl implements RequestFactory {
     if (prefix != null) {
       requestBuilder.prefix(prefix);
     }
-    return prepareV2Request(requestBuilder);
+    return prepareRequest(requestBuilder);
   }
 
   @Override
@@ -428,7 +403,7 @@ public class RequestFactoryImpl implements RequestFactory {
     AbortMultipartUploadRequest.Builder requestBuilder =
         AbortMultipartUploadRequest.builder().bucket(getBucket()).key(destKey).uploadId(uploadId);
 
-    return prepareV2Request(requestBuilder);
+    return prepareRequest(requestBuilder);
   }
 
   private void multipartUploadEncryptionParameters(CreateMultipartUploadRequest.Builder mpuRequestBuilder) {
@@ -475,7 +450,7 @@ public class RequestFactoryImpl implements RequestFactory {
       requestBuilder.storageClass(storageClass);
     }
 
-    return prepareV2Request(requestBuilder);
+    return prepareRequest(requestBuilder);
   }
 
   @Override
@@ -489,7 +464,7 @@ public class RequestFactoryImpl implements RequestFactory {
         CompleteMultipartUploadRequest.builder().bucket(bucket).key(destKey).uploadId(uploadId)
             .multipartUpload(CompletedMultipartUpload.builder().parts(partETags).build());
 
-    return prepareV2Request(requestBuilder);
+    return prepareRequest(requestBuilder);
   }
 
   @Override
@@ -505,7 +480,7 @@ public class RequestFactoryImpl implements RequestFactory {
           .sseCustomerKeyMD5(Md5Utils.md5AsBase64(Base64.getDecoder().decode(base64customerKey)));
     });
 
-    return prepareV2Request(headObjectRequestBuilder);
+    return prepareRequest(headObjectRequestBuilder);
   }
 
   @Override
@@ -521,7 +496,7 @@ public class RequestFactoryImpl implements RequestFactory {
           .sseCustomerKeyMD5(Md5Utils.md5AsBase64(Base64.getDecoder().decode(base64customerKey)));
     });
 
-    return prepareV2Request(builder);
+    return prepareRequest(builder);
   }
 
   @Override
@@ -551,7 +526,7 @@ public class RequestFactoryImpl implements RequestFactory {
         .partNumber(partNumber)
         .contentLength(size);
     uploadPartEncryptionParameters(builder);
-    return prepareV2Request(builder);
+    return prepareRequest(builder);
   }
 
   @Override
@@ -560,7 +535,10 @@ public class RequestFactoryImpl implements RequestFactory {
     request.setBucketName(bucket);
     request.setKey(key);
     generateSSECustomerKey().ifPresent(request::setSSECustomerKey);
-    return prepareRequest(request);
+
+    // TODO:WiP: revert when select is upgraded to v2
+    // return prepareRequest(requestBuilder);
+    return request;
   }
 
   @Override
@@ -576,13 +554,7 @@ public class RequestFactoryImpl implements RequestFactory {
       requestBuilder.delimiter(delimiter);
     }
 
-    return prepareV2Request(requestBuilder);
-  }
-
-  @Override
-  public ListNextBatchOfObjectsRequest newListNextBatchOfObjectsRequest(
-      ObjectListing prev) {
-    return prepareRequest(new ListNextBatchOfObjectsRequest(prev));
+    return prepareRequest(requestBuilder);
   }
 
   @Override
@@ -600,18 +572,18 @@ public class RequestFactoryImpl implements RequestFactory {
       requestBuilder.delimiter(delimiter);
     }
 
-    return prepareV2Request(requestBuilder);
+    return prepareRequest(requestBuilder);
   }
 
   @Override
   public DeleteObjectRequest.Builder newDeleteObjectRequestBuilder(String key) {
-    return prepareV2Request(DeleteObjectRequest.builder().bucket(bucket).key(key));
+    return prepareRequest(DeleteObjectRequest.builder().bucket(bucket).key(key));
   }
 
   @Override
   public DeleteObjectsRequest.Builder newBulkDeleteRequestBuilder(
           List<ObjectIdentifier> keysToDelete) {
-    return prepareV2Request(DeleteObjectsRequest
+    return prepareRequest(DeleteObjectsRequest
         .builder()
         .bucket(bucket)
         .delete(d -> d.objects(keysToDelete).quiet(true)));
@@ -766,11 +738,9 @@ public class RequestFactoryImpl implements RequestFactory {
 
     /**
      * Post-creation preparation of AWS request.
-     * @param t request
-     * @param <T> request type.
-     * @return prepared entry.
+     * @param t request builder
      */
     @Retries.OnceRaw
-    <T extends AmazonWebServiceRequest> T prepareRequest(T t);
+    void prepareRequest(SdkRequest.Builder t);
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/V2Migration.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/impl/V2Migration.java
@@ -47,6 +47,9 @@ public final class V2Migration {
   private static final LogExactlyOnce WARN_OF_CUSTOM_SIGNER =
       new LogExactlyOnce(SDK_V2_UPGRADE_LOG);
 
+  private static final LogExactlyOnce WARN_OF_REQUEST_HANDLERS =
+      new LogExactlyOnce(SDK_V2_UPGRADE_LOG);
+
   private static final LogExactlyOnce WARN_ON_GET_OBJECT_METADATA =
       new LogExactlyOnce(SDK_V2_UPGRADE_LOG);
 
@@ -84,6 +87,15 @@ public final class V2Migration {
   public static void v1CustomSignerUsed() {
     WARN_OF_CUSTOM_SIGNER.warn(
         "The signer interface has changed in AWS SDK V2, custom signers will need to be updated "
+            + "once S3A is upgraded to SDK V2");
+  }
+
+  /**
+   * Warns on use of request handlers.
+   */
+  public static void v1RequestHandlersUsed() {
+    WARN_OF_REQUEST_HANDLERS.warn(
+        "The request handler interface has changed in AWS SDK V2, use exception interceptors "
             + "once S3A is upgraded to SDK V2");
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/MockS3AFileSystem.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.net.URI;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.services.s3.AmazonS3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +50,7 @@ import org.apache.hadoop.fs.s3a.test.MinimalWriteOperationHelperCallbacks;
 import org.apache.hadoop.fs.statistics.DurationTrackerFactory;
 import org.apache.hadoop.util.Progressable;
 
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.noopAuditor;
@@ -118,9 +118,7 @@ public class MockS3AFileSystem extends S3AFileSystem {
     root = new Path(FS_URI.toString());
   }
 
-  private static <T extends AmazonWebServiceRequest> T prepareRequest(T t) {
-    return t;
-  }
+  private static void prepareRequest(SdkRequest.Builder t) {}
 
   @Override
   public RequestFactory getRequestFactory() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/AbstractAuditingTest.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/AbstractAuditingTest.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.fs.s3a.audit;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
 
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -35,6 +35,12 @@ import org.apache.hadoop.fs.statistics.IOStatisticAssertions;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
+
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 
 import static org.apache.hadoop.fs.s3a.Statistic.INVOCATION_GET_FILE_STATUS;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.UNAUDITED_OPERATION;
@@ -131,13 +137,24 @@ public abstract class AbstractAuditingTest extends AbstractHadoopTestBase {
   /**
    * Create a head request and pass it through the manager's beforeExecution()
    * callback.
+   *
    * @return a processed request.
    */
-  // TODO: Temporary change as auditor still expects V1 request, will be updated during auditor work.
-  protected GetObjectMetadataRequest head() {
-//    return manager.beforeExecution(
-//        requestFactory.newGetObjectMetadataRequest("/"));
-    return manager.beforeExecution(new GetObjectMetadataRequest("test", "/"));
+  protected SdkHttpRequest head() {
+    HeadObjectRequest.Builder headObjectRequestBuilder =
+        requestFactory.newHeadObjectRequestBuilder("/");
+    manager.requestCreated(headObjectRequestBuilder);
+    HeadObjectRequest headObjectRequest = headObjectRequestBuilder.build();
+    ExecutionAttributes executionAttributes = ExecutionAttributes.builder().build();
+    InterceptorContext context = InterceptorContext.builder()
+        .request(headObjectRequest)
+        .httpRequest(SdkHttpRequest.builder()
+            .uri(URI.create("https://test"))
+            .method(SdkHttpMethod.HEAD)
+            .build())
+        .build();
+    manager.beforeExecution(context, executionAttributes);
+    return manager.modifyHttpRequest(context, executionAttributes);
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/AuditTestSupport.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/AuditTestSupport.java
@@ -30,7 +30,7 @@ import static org.apache.hadoop.fs.s3a.Statistic.AUDIT_FAILURE;
 import static org.apache.hadoop.fs.s3a.Statistic.AUDIT_REQUEST_EXECUTION;
 import static org.apache.hadoop.fs.s3a.Statistic.AUDIT_SPAN_CREATION;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_ENABLED;
-import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_REQUEST_HANDLERS;
+import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_EXECUTION_INTERCEPTORS;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_SERVICE_CLASSNAME;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.LOGGING_AUDIT_SERVICE;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.NOOP_AUDIT_SERVICE;
@@ -119,7 +119,7 @@ public final class AuditTestSupport {
     S3ATestUtils.removeBaseAndBucketOverrides(conf,
         REFERRER_HEADER_ENABLED,
         REJECT_OUT_OF_SPAN_OPERATIONS,
-        AUDIT_REQUEST_HANDLERS,
+        AUDIT_EXECUTION_INTERCEPTORS,
         AUDIT_SERVICE_CLASSNAME,
         AUDIT_ENABLED);
     return conf;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/SimpleAWSExecutionInterceptor.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/SimpleAWSExecutionInterceptor.java
@@ -20,28 +20,28 @@ package org.apache.hadoop.fs.s3a.audit;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.handlers.RequestHandler2;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 /**
- * Simple AWS handler to verify dynamic loading of extra request
- * handlers during auditing setup.
+ * Simple AWS interceptor to verify dynamic loading of extra
+ * execution interceptors during auditing setup.
  * The invocation counter tracks the count of calls to
- * {@link #beforeExecution(AmazonWebServiceRequest)}.
+ * {@link #beforeExecution}.
  */
-public final class SimpleAWSRequestHandler extends RequestHandler2 {
+public final class SimpleAWSExecutionInterceptor implements ExecutionInterceptor {
 
   public static final String CLASS
-      = "org.apache.hadoop.fs.s3a.audit.SimpleAWSRequestHandler";
+      = "org.apache.hadoop.fs.s3a.audit.SimpleAWSExecutionInterceptor";
 
   /** Count of invocations. */
   private static final AtomicLong INVOCATIONS = new AtomicLong(0);
 
   @Override
-  public AmazonWebServiceRequest beforeExecution(
-      final AmazonWebServiceRequest request) {
+  public void beforeExecution(Context.BeforeExecution context,
+      ExecutionAttributes executionAttributes) {
     INVOCATIONS.incrementAndGet();
-    return request;
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditIntegration.java
@@ -194,8 +194,8 @@ public class TestAuditIntegration extends AbstractHadoopTestBase {
   @Test
   public void testNoopAuditManager() throws Throwable {
     AuditManagerS3A manager = AuditIntegration.stubAuditManager();
-    assertThat(manager.createStateChangeListener())
-        .describedAs("transfer state change listener")
+    assertThat(manager.createTransferListener())
+        .describedAs("transfer listener")
         .isNotNull();
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditIntegration.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditIntegration.java
@@ -20,14 +20,11 @@ package org.apache.hadoop.fs.s3a.audit;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
-import java.util.List;
 
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.s3a.api.RequestFactory;
 import org.apache.hadoop.fs.s3a.audit.impl.NoopAuditor;
-import org.apache.hadoop.fs.s3a.impl.RequestFactoryImpl;
 import org.apache.hadoop.fs.statistics.impl.IOStatisticsStore;
 import org.apache.hadoop.service.Service;
 import org.apache.hadoop.test.AbstractHadoopTestBase;
@@ -39,7 +36,7 @@ import static org.apache.hadoop.fs.s3a.audit.AuditIntegration.attachSpanToReques
 import static org.apache.hadoop.fs.s3a.audit.AuditIntegration.retrieveAttachedSpan;
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.createIOStatisticsStoreForAuditing;
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.noopAuditConfig;
-import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_REQUEST_HANDLERS;
+import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_EXECUTION_INTERCEPTORS;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.AUDIT_SERVICE_CLASSNAME;
 import static org.apache.hadoop.service.ServiceAssert.assertServiceStateStarted;
 import static org.apache.hadoop.service.ServiceAssert.assertServiceStateStopped;
@@ -173,14 +170,14 @@ public class TestAuditIntegration extends AbstractHadoopTestBase {
   public void testRequestHandlerLoading() throws Throwable {
     Configuration conf = noopAuditConfig();
     conf.setClassLoader(this.getClass().getClassLoader());
-    conf.set(AUDIT_REQUEST_HANDLERS,
-        SimpleAWSRequestHandler.CLASS);
+    conf.set(AUDIT_EXECUTION_INTERCEPTORS,
+        SimpleAWSExecutionInterceptor.CLASS);
     AuditManagerS3A manager = AuditIntegration.createAndStartAuditManager(
         conf,
         ioStatistics);
     assertThat(manager.createExecutionInterceptors())
         .hasSize(2)
-        .hasAtLeastOneElementOfType(SimpleAWSRequestHandler.class);
+        .hasAtLeastOneElementOfType(SimpleAWSExecutionInterceptor.class);
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditSpanLifecycle.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestAuditSpanLifecycle.java
@@ -20,12 +20,13 @@ package org.apache.hadoop.fs.s3a.audit;
 
 import java.util.List;
 
-import com.amazonaws.handlers.RequestHandler2;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
+
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.noopAuditConfig;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,10 +57,10 @@ public class TestAuditSpanLifecycle extends AbstractAuditingTest {
   }
 
   @Test
-  public void testCreateRequestHandlers() throws Throwable {
-    List<RequestHandler2> handlers
-        = getManager().createRequestHandlers();
-    assertThat(handlers).isNotEmpty();
+  public void testCreateExecutionInterceptors() throws Throwable {
+    List<ExecutionInterceptor> interceptors
+        = getManager().createExecutionInterceptors();
+    assertThat(interceptors).isNotEmpty();
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestHttpReferrerAuditHeader.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestHttpReferrerAuditHeader.java
@@ -19,10 +19,10 @@
 package org.apache.hadoop.fs.s3a.audit;
 
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -34,6 +34,9 @@ import org.apache.hadoop.fs.store.audit.AuditSpan;
 import org.apache.hadoop.fs.audit.CommonAuditContext;
 import org.apache.hadoop.fs.store.audit.HttpReferrerAuditHeader;
 import org.apache.hadoop.security.UserGroupInformation;
+
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.loggingAuditConfig;
 import static org.apache.hadoop.fs.s3a.audit.S3AAuditConstants.REFERRER_HEADER_FILTER;
@@ -92,13 +95,16 @@ public class TestHttpReferrerAuditHeader extends AbstractAuditingTest {
   public void testHttpReferrerPatchesTheRequest() throws Throwable {
     AuditSpan span = span();
     long ts = span.getTimestamp();
-    GetObjectMetadataRequest request = head();
-    Map<String, String> headers
-        = request.getCustomRequestHeaders();
+    SdkHttpRequest request = head();
+    Map<String, List<String>> headers = request.headers();
     assertThat(headers)
         .describedAs("Custom headers")
         .containsKey(HEADER_REFERRER);
-    String header = headers.get(HEADER_REFERRER);
+    List<String> headerValues = headers.get(HEADER_REFERRER);
+    assertThat(headerValues)
+        .describedAs("Multiple referrer headers")
+        .hasSize(1);
+    String header = headerValues.get(0);
     LOG.info("Header is {}", header);
     Map<String, String> params
         = HttpReferrerAuditHeader.extractQueryParameters(header);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestLoggingAuditor.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/audit/TestLoggingAuditor.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.fs.s3a.audit;
 
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
-import com.amazonaws.services.s3.model.CopyPartRequest;
 import com.amazonaws.services.s3.transfer.internal.TransferStateChangeListener;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +27,12 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.audit.impl.LoggingAuditor;
 import org.apache.hadoop.fs.store.audit.AuditSpan;
+
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.InterceptorContext;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
 
 import static org.apache.hadoop.fs.s3a.audit.AuditTestSupport.loggingAuditConfig;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -131,8 +135,20 @@ public class TestLoggingAuditor extends AbstractAuditingTest {
    */
   @Test
   public void testCopyOutsideSpanAllowed() throws Throwable {
-    getManager().beforeExecution(new CopyPartRequest());
-    getManager().beforeExecution(new CompleteMultipartUploadRequest());
+    // TODO:WiP: equivalent in v2?
+    //getManager().beforeExecution(new CopyPartRequest());
+    getManager().beforeExecution(
+        InterceptorContext.builder()
+            .request(GetBucketLocationRequest.builder().build())
+            .build(),
+        ExecutionAttributes.builder().build());
+    getManager().beforeExecution(
+        InterceptorContext.builder()
+            .request(CompleteMultipartUploadRequest.builder()
+                .multipartUpload(u -> {})
+                .build())
+            .build(),
+        ExecutionAttributes.builder().build());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
@@ -135,14 +136,16 @@ public class TestRequestFactory extends AbstractHadoopTestBase {
     private final AtomicLong counter = new AtomicLong();
 
     @Override
-    public <T extends AmazonWebServiceRequest> T prepareRequest(final T t) {
+    public void prepareRequest(final SdkRequest.Builder t) {
       counter.addAndGet(1);
-      return t;
     }
   }
 
-  private <T extends AwsRequest> void a(AwsRequest.Builder request) {
-    // TODO: Implement for SDK v2 requests
+  private <T extends AwsRequest> AWSRequestAnalyzer.RequestInfo a(AwsRequest.Builder request) {
+    AWSRequestAnalyzer.RequestInfo info = analyzer.analyze(request.build());
+    LOG.info("{}", info);
+    requestsAnalyzed++;
+    return info;
   }
 
   /**
@@ -167,28 +170,24 @@ public class TestRequestFactory extends AbstractHadoopTestBase {
     String path = "path";
     String path2 = "path2";
     String id = "1";
-   // ObjectMetadata md = factory.newObjectMetadata(128);
-   // a(factory.newAbortMultipartUploadRequest(path, id));
-   // a(factory.newCompleteMultipartUploadRequest(path, id,
-   //     new ArrayList<>()));
-   // a(factory.newCopyObjectRequest(path, path2, md));
+    a(factory.newAbortMultipartUploadRequestBuilder(path, id));
+    a(factory.newCompleteMultipartUploadRequestBuilder(path, id,
+        new ArrayList<>()));
+    a(factory.newCopyObjectRequestBuilder(path, path2,
+        HeadObjectResponse.builder().build()));
     a(factory.newDeleteObjectRequestBuilder(path));
     a(factory.newBulkDeleteRequestBuilder(new ArrayList<>()));
-   // a(factory.newDirectoryMarkerRequest(path));
+    a(factory.newDirectoryMarkerRequest(path));
     a(factory.newGetObjectRequestBuilder(path));
-   // a(factory.newGetObjectMetadataRequest(path));
-   // a(factory.newListMultipartUploadsRequest(path));
-    //TODO: Commenting out for now, new request extends AwsRequest, this can be updated once all
-    // request factory operations are updated.
-    //a(factory.newListObjectsV1Request(path, "/", 1));
-    a(factory.newListNextBatchOfObjectsRequest(new ObjectListing()));
-    // a(factory.newListObjectsV2Request(path, "/", 1));
-    //a(factory.newMultipartUploadRequest(path, null));
-    File srcfile = new File("/tmp/a");
-//    a(factory.newPutObjectRequest(path,
-//        factory.newObjectMetadata(-1), null, srcfile));
-    ByteArrayInputStream stream = new ByteArrayInputStream(new byte[0]);
-   // a(factory.newPutObjectRequest(path, md, null, stream));
+    a(factory.newHeadObjectRequestBuilder(path));
+    a(factory.newListMultipartUploadsRequestBuilder(path));
+    a(factory.newListObjectsV1RequestBuilder(path, "/", 1));
+    a(factory.newListObjectsV2RequestBuilder(path, "/", 1));
+    a(factory.newMultipartUploadRequestBuilder(path, null));
+    a(factory.newPutObjectRequestBuilder(path,
+        PutObjectOptions.keepingDirs(), -1, true));
+    a(factory.newPutObjectRequestBuilder(path,
+        PutObjectOptions.deletingDirs(), 1024, false));
     a(factory.newSelectRequest(path));
   }
 

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/impl/TestRequestFactory.java
@@ -141,7 +141,7 @@ public class TestRequestFactory extends AbstractHadoopTestBase {
     }
   }
 
-  private <T extends AwsRequest> AWSRequestAnalyzer.RequestInfo a(AwsRequest.Builder request) {
+  private AWSRequestAnalyzer.RequestInfo a(AwsRequest.Builder request) {
     AWSRequestAnalyzer.RequestInfo info = analyzer.analyze(request.build());
     LOG.info("{}", info);
     requestsAnalyzed++;


### PR DESCRIPTION
Upgrade auditors to use the SDK v2. 

`ExecutionInterceptor` replaces `RequestHandler2`:
* Simplification in `AWSAuditEventCallbacks` (and implementors) which can now extend `ExecutionInterceptor`
* "Registering" a Span with a request has moved from requestCreated to beforeExecution (when an `ExecutionAttributes` instance is first available)
* The ReferrerHeader is build and added to the http request in modifyHttpRequest (rather than beforeExecution, when no http request is yet available)
* Dynamic loading of interceptors has been implemented to reproduce previous behaviour with `RequestHandler2`s. The AWS SDK v2 offers a similar mechanism - see https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/interceptor/ExecutionInterceptor.html - which could make it redundant.

`TransferManager` replaces `TransferStateChangeListener` for TransferManager requests:
* Registration is currently commented out because it causes an issue with the logger (to be further investigated).


