### PR TITLE
HADOOP-18073. Updates credential providers.

### DIFF
--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AnonymousAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/AnonymousAWSCredentialsProvider.java
@@ -18,9 +18,10 @@
 
 package org.apache.hadoop.fs.s3a;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.auth.AWSCredentials;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 
@@ -35,22 +36,17 @@ import org.apache.hadoop.classification.InterfaceStability;
  * property fs.s3a.aws.credentials.provider.  Therefore, changing the class name
  * would be a backward-incompatible change.
  *
- * @deprecated This class will be replaced by one that implements AWS SDK V2's AwsCredentialProvider
- * as part of upgrading S3A to SDK V2. See HADOOP-18073.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Stable
-@Deprecated
-public class AnonymousAWSCredentialsProvider implements AWSCredentialsProvider {
+public class AnonymousAWSCredentialsProvider implements AwsCredentialsProvider {
 
   public static final String NAME
       = "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider";
 
-  public AWSCredentials getCredentials() {
-    return new AnonymousAWSCredentials();
+  public AwsCredentials resolveCredentials() {
+    return AnonymousCredentialsProvider.create().resolveCredentials();
   }
-
-  public void refresh() {}
 
   @Override
   public String toString() {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -194,6 +194,7 @@ public class DefaultS3ClientFactory extends Configured
 
     Configuration conf = getConf();
     bucket = uri.getHost();
+
     ApacheHttpClient.Builder httpClientBuilder = AWSClientConfig
         .createHttpClientBuilder(conf)
         .proxyConfiguration(AWSClientConfig.createProxyConfiguration(conf, bucket));

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/DefaultS3ClientFactory.java
@@ -50,6 +50,8 @@ import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
@@ -251,10 +253,7 @@ public class DefaultS3ClientFactory extends Configured
 
     return builder
         .overrideConfiguration(createClientOverrideConfiguration(parameters, conf))
-        .credentialsProvider(
-            // use adapter classes so V1 credential providers continue to work. This will
-            // be moved to AWSCredentialProviderList.add() when that class is updated.
-            V1V2AwsCredentialProviderAdapter.adapt(parameters.getCredentialSet()))
+        .credentialsProvider(parameters.getCredentialSet())
         .endpointOverride(endpoint)
         .region(region)
         .serviceConfiguration(serviceConfiguration);
@@ -387,7 +386,8 @@ public class DefaultS3ClientFactory extends Configured
    */
   private void configureBasicParams(AmazonS3Builder builder,
       ClientConfiguration awsConf, S3ClientCreationParameters parameters) {
-    builder.withCredentials(parameters.getCredentialSet());
+    // TODO: This whole block will be removed when we remove the V1 client.
+   // builder.withCredentials(parameters.getCredentialSet());
     builder.withClientConfiguration(awsConf);
     builder.withPathStyleAccessEnabled(parameters.isPathStyleAccess());
 
@@ -562,7 +562,7 @@ public class DefaultS3ClientFactory extends Configured
    * @return region of the bucket.
    */
   private static Region getS3Region(String region, String bucket,
-      AWSCredentialsProvider credentialsProvider) {
+      AwsCredentialsProvider credentialsProvider) {
 
     if (!StringUtils.isBlank(region)) {
       return Region.of(region);
@@ -575,7 +575,7 @@ public class DefaultS3ClientFactory extends Configured
       // the actual region the bucket is in. As the request is signed with us-east-1 and not the
       // bucket's region, it fails.
       S3Client s3Client = S3Client.builder().region(Region.EU_WEST_1)
-          .credentialsProvider(V1V2AwsCredentialProviderAdapter.adapt(credentialsProvider))
+          .credentialsProvider(credentialsProvider)
           .build();
 
       HeadBucketResponse headBucketResponse =

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/InconsistentS3ClientFactory.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.fs.s3a;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -44,8 +46,17 @@ public class InconsistentS3ClientFactory extends DefaultS3ClientFactory {
     LOG.warn("** FAILURE INJECTION ENABLED.  Do not run in production! **");
     LOG.warn("List inconsistency is no longer emulated; only throttling and read errors");
     InconsistentAmazonS3Client s3
-        = new InconsistentAmazonS3Client(
-            parameters.getCredentialSet(), awsConf, getConf());
+        = new InconsistentAmazonS3Client(new AWSStaticCredentialsProvider(new AWSCredentials() {
+      @Override
+      public String getAWSAccessKeyId() {
+        return null;
+      }
+
+      @Override
+      public String getAWSSecretKey() {
+        return null;
+      }
+    }), awsConf, getConf());
     configureAmazonS3Client(s3,
         parameters.getEndpoint(),
         parameters.isPathStyleAccess());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.util.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -109,6 +110,8 @@ public final class S3AUtils {
       = "instantiation exception";
   static final String NOT_AWS_PROVIDER =
       "does not implement AWSCredentialsProvider";
+  static final String NOT_AWS_V2_PROVIDER =
+      "does not implement AwsCredentialsProvider";
   static final String ABSTRACT_PROVIDER =
       "is abstract and therefore cannot be created";
   static final String ENDPOINT_KEY = "Endpoint";
@@ -653,16 +656,22 @@ public final class S3AUtils {
     AWSCredentialProviderList providers = new AWSCredentialProviderList();
     for (Class<?> aClass : awsClasses) {
 
-      if (aClass.getName().contains(AWS_AUTH_CLASS_PREFIX)) {
-        V2Migration.v1ProviderReferenced(aClass.getName());
-      }
-
       if (forbidden.contains(aClass)) {
         throw new IOException(E_FORBIDDEN_AWS_PROVIDER
             + " in option " + key + ": " + aClass);
       }
-      providers.add(createAWSCredentialProvider(conf,
-          aClass, binding));
+
+      // TODO: Not sure what to do here yet.
+      //  There were some V1 providers for which we suppressed warnings, how do we map those?
+      if (aClass.getName().contains(AWS_AUTH_CLASS_PREFIX)) {
+        // V2Migration.v1ProviderReferenced(aClass.getName());
+
+        providers.add(createAWSV1CredentialProvider(conf,
+            aClass, binding));
+      } else {
+        providers.add(createAWSV2CredentialProvider(conf, aClass, binding));
+      }
+
     }
     return providers;
   }
@@ -689,7 +698,7 @@ public final class S3AUtils {
    * @return the instantiated class
    * @throws IOException on any instantiation failure.
    */
-  private static AWSCredentialsProvider createAWSCredentialProvider(
+  private static AWSCredentialsProvider createAWSV1CredentialProvider(
       Configuration conf,
       Class<?> credClass,
       @Nullable URI uri) throws IOException {
@@ -762,6 +771,104 @@ public final class S3AUtils {
           e);
     }
   }
+
+  /**
+   * Create an AWS credential provider from its class by using reflection.  The
+   * class must implement one of the following means of construction, which are
+   * attempted in order:
+   *
+   * <ol>
+   * <li>a public constructor accepting java.net.URI and
+   *     org.apache.hadoop.conf.Configuration</li>
+   * <li>a public constructor accepting
+   *    org.apache.hadoop.conf.Configuration</li>
+   * <li>a public static method named getInstance that accepts no
+   *    arguments and returns an instance of
+   *    com.amazonaws.auth.AWSCredentialsProvider, or</li>
+   * <li>a public default constructor.</li>
+   * </ol>
+   *
+   * @param conf configuration
+   * @param credClass credential class
+   * @param uri URI of the FS
+   * @return the instantiated class
+   * @throws IOException on any instantiation failure.
+   */
+  private static AwsCredentialsProvider createAWSV2CredentialProvider(
+      Configuration conf,
+      Class<?> credClass,
+      @Nullable URI uri) throws IOException {
+    AwsCredentialsProvider credentials = null;
+    String className = credClass.getName();
+    if (!AwsCredentialsProvider.class.isAssignableFrom(credClass)) {
+      throw new IOException("Class " + credClass + " " + NOT_AWS_V2_PROVIDER);
+    }
+    if (Modifier.isAbstract(credClass.getModifiers())) {
+      throw new IOException("Class " + credClass + " " + ABSTRACT_PROVIDER);
+    }
+    LOG.debug("Credential provider class is {}", className);
+
+    try {
+      // new X(uri, conf)
+      Constructor cons = getConstructor(credClass, URI.class,
+          Configuration.class);
+      if (cons != null) {
+        credentials = (AwsCredentialsProvider)cons.newInstance(uri, conf);
+        return credentials;
+      }
+      // new X(conf)
+      cons = getConstructor(credClass, Configuration.class);
+      if (cons != null) {
+        credentials = (AwsCredentialsProvider)cons.newInstance(conf);
+        return credentials;
+      }
+
+      // X.getInstance()
+      Method factory = getFactoryMethod(credClass, AwsCredentialsProvider.class,
+          "getInstance");
+      if (factory != null) {
+        credentials = (AwsCredentialsProvider)factory.invoke(null);
+        return credentials;
+      }
+
+      // new X()
+      cons = getConstructor(credClass);
+      if (cons != null) {
+        credentials = (AwsCredentialsProvider)cons.newInstance();
+        return credentials;
+      }
+
+      // no supported constructor or factory method found
+      throw new IOException(String.format("%s " + CONSTRUCTOR_EXCEPTION
+              + ".  A class specified in %s must provide a public constructor "
+              + "of a supported signature, or a public factory method named "
+              + "getInstance that accepts no arguments.",
+          className, AWS_CREDENTIALS_PROVIDER));
+    } catch (InvocationTargetException e) {
+      // TODO: Can probably be moved to a common method
+      Throwable targetException = e.getTargetException();
+      if (targetException == null) {
+        targetException =  e;
+      }
+      if (targetException instanceof IOException) {
+        throw (IOException) targetException;
+      } else if (targetException instanceof SdkException) {
+        throw translateException("Instantiate " + className, "",
+            (SdkException) targetException);
+      } else {
+        // supported constructor or factory method found, but the call failed
+        throw new IOException(className + " " + INSTANTIATION_EXCEPTION
+            + ": " + targetException,
+            targetException);
+      }
+    } catch (ReflectiveOperationException | IllegalArgumentException e) {
+      // supported constructor or factory method found, but the call failed
+      throw new IOException(className + " " + INSTANTIATION_EXCEPTION
+          + ": " + e,
+          e);
+    }
+  }
+
 
   /**
    * Set a key if the value is non-empty.

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.util.functional.RemoteIterators;
 import org.apache.hadoop.fs.s3a.auth.delegation.EncryptionSecrets;
 import org.apache.hadoop.fs.s3a.auth.IAMInstanceCredentialsProvider;
 import org.apache.hadoop.fs.s3a.impl.NetworkBinding;
-import org.apache.hadoop.fs.s3a.impl.V2Migration;
 import org.apache.hadoop.fs.s3native.S3xLoginHelper;
 import org.apache.hadoop.net.ConnectTimeoutException;
 import org.apache.hadoop.security.ProviderUtils;
@@ -54,7 +53,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.core.retry.RetryUtils;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -845,7 +843,8 @@ public final class S3AUtils {
               + "getInstance that accepts no arguments.",
           className, AWS_CREDENTIALS_PROVIDER));
     } catch (InvocationTargetException e) {
-      // TODO: Can probably be moved to a common method
+      // TODO: Can probably be moved to a common method, but before doing this, check if we still
+      //  want to extend V2 providers the same way v1 providers are.
       Throwable targetException = e.getTargetException();
       if (targetException == null) {
         targetException =  e;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AUtils.java
@@ -782,7 +782,7 @@ public final class S3AUtils {
    *    org.apache.hadoop.conf.Configuration</li>
    * <li>a public static method named getInstance that accepts no
    *    arguments and returns an instance of
-   *    com.amazonaws.auth.AWSCredentialsProvider, or</li>
+   *    software.amazon.awssdk.auth.credentials.AwsCredentialsProvider, or</li>
    * <li>a public default constructor.</li>
    * </ol>
    *

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3ClientFactory.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.s3a.statistics.StatisticsFromAwsSdk;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -105,7 +106,7 @@ public interface S3ClientFactory {
     /**
      * Credentials.
      */
-    private AWSCredentialsProvider credentialSet;
+    private AwsCredentialsProvider credentialSet;
 
     /**
      * Endpoint.
@@ -222,7 +223,7 @@ public interface S3ClientFactory {
       return requesterPays;
     }
 
-    public AWSCredentialsProvider getCredentialSet() {
+    public AwsCredentialsProvider getCredentialSet() {
       return credentialSet;
     }
 
@@ -233,7 +234,7 @@ public interface S3ClientFactory {
      */
 
     public S3ClientCreationParameters withCredentialSet(
-        final AWSCredentialsProvider value) {
+        final AwsCredentialsProvider value) {
       credentialSet = value;
       return this;
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/SharedInstanceCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/SharedInstanceCredentialProvider.java
@@ -39,6 +39,5 @@ import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
-@SuppressWarnings("deprecation")
 public final class SharedInstanceCredentialProvider extends IAMInstanceCredentialsProvider {
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/SimpleAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/SimpleAWSCredentialsProvider.java
@@ -21,6 +21,10 @@ package org.apache.hadoop.fs.s3a;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
 import org.apache.hadoop.classification.VisibleForTesting;
 
 import org.apache.commons.lang3.StringUtils;
@@ -42,13 +46,10 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.getAWSAccessKeys;
  * property fs.s3a.aws.credentials.provider.  Therefore, changing the class name
  * would be a backward-incompatible change.
  *
- * @deprecated This class will be replaced by one that implements AWS SDK V2's AwsCredentialProvider
- * as part of upgrading S3A to SDK V2. See HADOOP-18073.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-@Deprecated
-public class SimpleAWSCredentialsProvider implements AWSCredentialsProvider {
+public class SimpleAWSCredentialsProvider implements AwsCredentialsProvider {
 
   public static final String NAME
       = "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider";
@@ -80,16 +81,13 @@ public class SimpleAWSCredentialsProvider implements AWSCredentialsProvider {
   }
 
   @Override
-  public AWSCredentials getCredentials() {
+  public AwsCredentials resolveCredentials() {
     if (!StringUtils.isEmpty(accessKey) && !StringUtils.isEmpty(secretKey)) {
-      return new BasicAWSCredentials(accessKey, secretKey);
+      return AwsBasicCredentials.create(accessKey, secretKey);
     }
     throw new NoAwsCredentialsException("SimpleAWSCredentialsProvider",
         "No AWS credentials in the Hadoop configuration");
   }
-
-  @Override
-  public void refresh() {}
 
   @Override
   public String toString() {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/TemporaryAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/TemporaryAWSCredentialsProvider.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 import com.amazonaws.auth.AWSCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import java.net.URI;
 
@@ -44,12 +45,9 @@ import org.apache.hadoop.fs.s3a.auth.NoAwsCredentialsException;
  * This credential provider must not fail in creation because that will
  * break a chain of credential providers.
  *
- * @deprecated This class will be replaced by one that implements AWS SDK V2's AwsCredentialProvider
- * as part of upgrading S3A to SDK V2. See HADOOP-18073.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-@Deprecated
 public class TemporaryAWSCredentialsProvider extends AbstractSessionCredentialsProvider {
 
   public static final String NAME
@@ -92,7 +90,7 @@ public class TemporaryAWSCredentialsProvider extends AbstractSessionCredentialsP
    * @throws NoAwsCredentialsException the credentials are actually empty.
    */
   @Override
-  protected AWSCredentials createCredentials(Configuration config)
+  protected AwsCredentials createCredentials(Configuration config)
       throws IOException {
     MarshalledCredentials creds = MarshalledCredentialBinding.fromFileSystem(
         getUri(), config);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AbstractAWSCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AbstractAWSCredentialProvider.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.fs.s3a.auth;
 import javax.annotation.Nullable;
 import java.net.URI;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import org.apache.hadoop.conf.Configuration;
 
@@ -29,12 +29,9 @@ import org.apache.hadoop.conf.Configuration;
  * Base class for AWS credential providers which
  * take a URI and config in their constructor.
  *
- * @deprecated This class will be replaced by one that implements AWS SDK V2's AwsCredentialProvider
- * as part of upgrading S3A to SDK V2. See HADOOP-18073.
  */
-@Deprecated
 public abstract class AbstractAWSCredentialProvider
-    implements AWSCredentialsProvider {
+    implements AwsCredentialsProvider {
 
   private final URI binding;
 
@@ -65,10 +62,4 @@ public abstract class AbstractAWSCredentialProvider
     return binding;
   }
 
-  /**
-   * Refresh is a no-op by default.
-   */
-  @Override
-  public void refresh() {
-  }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AbstractSessionCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AbstractSessionCredentialsProvider.java
@@ -32,21 +32,19 @@ import org.apache.hadoop.fs.s3a.CredentialInitializationException;
 import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.Retries;
 
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.core.exception.SdkException;
 
 /**
  * Base class for session credential support.
  *
- * @deprecated This class will be replaced by one that implements AWS SDK V2's AwsCredentialProvider
- * as part of upgrading S3A to SDK V2. See HADOOP-18073.
  */
 @InterfaceAudience.Private
-@Deprecated
 public abstract class AbstractSessionCredentialsProvider
     extends AbstractAWSCredentialProvider {
 
   /** Credentials, created in {@link #init()}. */
-  private AWSCredentials awsCredentials;
+  private AwsCredentials awsCredentials;
 
   /** Atomic flag for on-demand initialization. */
   private final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -104,7 +102,7 @@ public abstract class AbstractSessionCredentialsProvider
    * @return the credentials
    * @throws IOException on any failure.
    */
-  protected abstract AWSCredentials createCredentials(Configuration config)
+  protected abstract AwsCredentials createCredentials(Configuration config)
       throws IOException;
 
   /**
@@ -117,7 +115,7 @@ public abstract class AbstractSessionCredentialsProvider
    * @throws SdkException if one was raised during init
    * @throws CredentialInitializationException on other failures.
    */
-  public AWSCredentials getCredentials() throws SdkException {
+  public AwsCredentials resolveCredentials() throws SdkException {
     // do an on-demand init then raise an AWS SDK exception if
     // there was a failure.
     try {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
@@ -26,16 +26,17 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -50,6 +51,7 @@ import org.apache.hadoop.fs.s3a.S3ARetryPolicy;
 import org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3AUtils.buildAWSProviderList;
 
@@ -61,13 +63,10 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.buildAWSProviderList;
  *
  * Classname is used in configuration files; do not move.
  *
- * @deprecated This class will be replaced by one that implements AWS SDK V2's AwsCredentialProvider
- * as part of upgrading S3A to SDK V2. See HADOOP-18073.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
-@Deprecated
-public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
+public class AssumedRoleCredentialProvider implements AwsCredentialsProvider,
     Closeable {
 
   private static final Logger LOG =
@@ -78,7 +77,7 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
   public static final String E_NO_ROLE = "Unset property "
       + ASSUMED_ROLE_ARN;
 
-  private final STSAssumeRoleSessionCredentialsProvider stsProvider;
+  private final StsAssumeRoleCredentialsProvider stsProvider;
 
   private final String sessionName;
 
@@ -125,29 +124,30 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
     String policy = conf.getTrimmed(ASSUMED_ROLE_POLICY, "");
 
     LOG.debug("{}", this);
-    STSAssumeRoleSessionCredentialsProvider.Builder builder
-        = new STSAssumeRoleSessionCredentialsProvider.Builder(arn, sessionName);
-    builder.withRoleSessionDurationSeconds((int) duration);
+
+    AssumeRoleRequest.Builder requestBuilder =
+        AssumeRoleRequest.builder().roleArn(arn).roleSessionName(sessionName)
+            .durationSeconds((int) duration);
+
     if (StringUtils.isNotEmpty(policy)) {
       LOG.debug("Scope down policy {}", policy);
-      builder.withScopeDownPolicy(policy);
+      // TODO: Check this!
+     // requestBuilder.withScopeDownPolicy(policy);
     }
+
     String endpoint = conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT, "");
     String region = conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT_REGION,
         ASSUMED_ROLE_STS_ENDPOINT_REGION_DEFAULT);
-    AWSSecurityTokenServiceClientBuilder stsbuilder =
+    StsClientBuilder stsbuilder =
         STSClientFactory.builder(
           conf,
           fsUri != null ?  fsUri.getHost() : "",
           credentialsToSTS,
           endpoint,
           region);
-    // the STS client is not tracked for a shutdown in close(), because it
-    // (currently) throws an UnsupportedOperationException in shutdown().
-    builder.withStsClient(stsbuilder.build());
 
     //now build the provider
-    stsProvider = builder.build();
+    stsProvider = StsAssumeRoleCredentialsProvider.builder().stsClient(stsbuilder.build()).build();
 
     // to handle STS throttling by the AWS account, we
     // need to retry
@@ -155,7 +155,7 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
 
     // and force in a fail-fast check just to keep the stack traces less
     // convoluted
-    getCredentials();
+    resolveCredentials();
   }
 
   /**
@@ -165,11 +165,12 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
    */
   @Override
   @Retries.RetryRaw
-  public AWSCredentials getCredentials() {
+  public AwsCredentials resolveCredentials() {
     try {
       return invoker.retryUntranslated("getCredentials",
           true,
-          stsProvider::getCredentials);
+          stsProvider::resolveCredentials);
+      // TODO: Check this!!
     } catch (IOException e) {
       // this is in the signature of retryUntranslated;
       // its hard to see how this could be raised, but for
@@ -178,16 +179,11 @@ public class AssumedRoleCredentialProvider implements AWSCredentialsProvider,
       throw new CredentialInitializationException(
           "getCredentials failed: " + e,
           e);
-    } catch (AWSSecurityTokenServiceException e) {
+    } catch (SdkClientException e) {
       LOG.error("Failed to get credentials for role {}",
           arn, e);
       throw e;
     }
-  }
-
-  @Override
-  public void refresh() {
-    stsProvider.refresh();
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/AssumedRoleCredentialProvider.java
@@ -35,9 +35,9 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.StsException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -99,7 +99,7 @@ public class AssumedRoleCredentialProvider implements AwsCredentialsProvider,
    * @param conf configuration
    * @throws IOException on IO problems and some parameter checking
    * @throws IllegalArgumentException invalid parameters
-   * @throws AWSSecurityTokenServiceException problems getting credentials
+   * @throws StsException problems getting credentials
    */
   public AssumedRoleCredentialProvider(@Nullable URI fsUri, Configuration conf)
       throws IOException {
@@ -133,8 +133,7 @@ public class AssumedRoleCredentialProvider implements AwsCredentialsProvider,
 
     if (StringUtils.isNotEmpty(policy)) {
       LOG.debug("Scope down policy {}", policy);
-      // TODO: Don't see an equivalent in V2.
-     // requestBuilder.withScopeDownPolicy(policy);
+      requestBuilder.policy(policy);
     }
 
     String endpoint = conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT, "");
@@ -165,7 +164,7 @@ public class AssumedRoleCredentialProvider implements AwsCredentialsProvider,
   /**
    * Get credentials.
    * @return the credentials
-   * @throws AWSSecurityTokenServiceException if none could be obtained.
+   * @throws StsException if none could be obtained.
    */
   @Override
   @Retries.RetryRaw

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialBinding.java
@@ -24,18 +24,16 @@ import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.ClientConfiguration;
 import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSSessionCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.model.Credentials;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.Invoker;
@@ -77,10 +75,10 @@ public final class MarshalledCredentialBinding {
   public static MarshalledCredentials fromSTSCredentials(
       final Credentials credentials) {
     MarshalledCredentials marshalled = new MarshalledCredentials(
-        credentials.getAccessKeyId(),
-        credentials.getSecretAccessKey(),
-        credentials.getSessionToken());
-    Date date = credentials.getExpiration();
+        credentials.accessKeyId(),
+        credentials.secretAccessKey(),
+        credentials.sessionToken());
+    Date date = Date.from(credentials.expiration());
     marshalled.setExpiration(date != null ? date.getTime() : 0);
     return marshalled;
   }
@@ -91,11 +89,11 @@ public final class MarshalledCredentialBinding {
    * @return a set of marshalled credentials.
    */
   public static MarshalledCredentials fromAWSCredentials(
-      final AWSSessionCredentials credentials) {
+      final AwsSessionCredentials credentials) {
     return new MarshalledCredentials(
-        credentials.getAWSAccessKeyId(),
-        credentials.getAWSSecretKey(),
-        credentials.getSessionToken());
+        credentials.accessKeyId(),
+        credentials.secretAccessKey(),
+        credentials.sessionToken());
   }
 
   /**
@@ -156,7 +154,7 @@ public final class MarshalledCredentialBinding {
    * @throws NoAuthWithAWSException validation failure
    * @throws NoAwsCredentialsException the credentials are actually empty.
    */
-  public static AWSCredentials toAWSCredentials(
+  public static AwsCredentials toAWSCredentials(
       final MarshalledCredentials marshalled,
       final MarshalledCredentials.CredentialTypeRequired typeRequired,
       final String component)
@@ -173,11 +171,11 @@ public final class MarshalledCredentialBinding {
     final String secretKey = marshalled.getSecretKey();
     if (marshalled.hasSessionToken()) {
       // a session token was supplied, so return session credentials
-      return new BasicSessionCredentials(accessKey, secretKey,
+      return AwsSessionCredentials.create(accessKey, secretKey,
           marshalled.getSessionToken());
     } else {
       // these are full credentials
-      return new BasicAWSCredentials(accessKey, secretKey);
+      return AwsBasicCredentials.create(accessKey, secretKey);
     }
   }
 
@@ -194,18 +192,18 @@ public final class MarshalledCredentialBinding {
    */
   @Retries.RetryTranslated
   public static MarshalledCredentials requestSessionCredentials(
-      final AWSCredentialsProvider parentCredentials,
-      final ClientConfiguration awsConf,
+      final AwsCredentialsProvider parentCredentials,
+      final Configuration configuration,
       final String stsEndpoint,
       final String stsRegion,
       final int duration,
       final Invoker invoker) throws IOException {
     try {
-      final AWSSecurityTokenService tokenService =
+      final StsClient tokenService =
           STSClientFactory.builder(parentCredentials,
-              awsConf,
+              configuration,
               stsEndpoint.isEmpty() ? null : stsEndpoint,
-              stsRegion)
+              stsRegion, "b")
               .build();
       try (STSClientFactory.STSClient stsClient = STSClientFactory.createClientConnection(
           tokenService, invoker)) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialBinding.java
@@ -182,7 +182,7 @@ public final class MarshalledCredentialBinding {
   /**
    * Request a set of credentials from an STS endpoint.
    * @param parentCredentials the parent credentials needed to talk to STS
-   * @param awsConf AWS client configuration
+   * @param configuration AWS client configuration
    * @param stsEndpoint an endpoint, use "" for none
    * @param stsRegion region; use if the endpoint isn't the AWS default.
    * @param duration duration of the credentials in seconds. Minimum value: 900.
@@ -197,13 +197,14 @@ public final class MarshalledCredentialBinding {
       final String stsEndpoint,
       final String stsRegion,
       final int duration,
-      final Invoker invoker) throws IOException {
+      final Invoker invoker,
+      final String bucket) throws IOException {
     try {
       final StsClient tokenService =
           STSClientFactory.builder(parentCredentials,
               configuration,
               stsEndpoint.isEmpty() ? null : stsEndpoint,
-              stsRegion, "b")
+              stsRegion, bucket)
               .build();
       try (STSClientFactory.STSClient stsClient = STSClientFactory.createClientConnection(
           tokenService, invoker)) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialProvider.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/MarshalledCredentialProvider.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.net.URI;
 
 import com.amazonaws.auth.AWSCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -85,7 +86,7 @@ public class MarshalledCredentialProvider extends
    * @throws IOException on a failure
    */
   @Override
-  protected AWSCredentials createCredentials(final Configuration config)
+  protected AwsCredentials createCredentials(final Configuration config)
       throws IOException {
     return toAWSCredentials(credentials, typeRequired, component);
   }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
@@ -20,31 +20,37 @@ package org.apache.hadoop.fs.s3a.auth;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
-import com.amazonaws.services.securitytoken.model.Credentials;
-import com.amazonaws.services.securitytoken.model.GetSessionTokenRequest;
+import org.apache.hadoop.fs.s3a.AWSClientConfig;
 import org.apache.hadoop.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache.ProxyConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.Retries;
-import org.apache.hadoop.fs.s3a.S3AUtils;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
+import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.*;
 
 /**
@@ -71,17 +77,15 @@ public class STSClientFactory {
    * @return the builder to call {@code build()}
    * @throws IOException problem reading proxy secrets
    */
-  public static AWSSecurityTokenServiceClientBuilder builder(
+  public static StsClientBuilder builder(
       final Configuration conf,
       final String bucket,
-      final AWSCredentialsProvider credentials) throws IOException {
-    final ClientConfiguration awsConf = S3AUtils.createAwsConf(conf, bucket,
-        Constants.AWS_SERVICE_IDENTIFIER_STS);
+      final AwsCredentialsProvider credentials) throws IOException {
     String endpoint = conf.getTrimmed(DELEGATION_TOKEN_ENDPOINT,
         DEFAULT_DELEGATION_TOKEN_ENDPOINT);
     String region = conf.getTrimmed(DELEGATION_TOKEN_REGION,
         DEFAULT_DELEGATION_TOKEN_REGION);
-    return builder(credentials, awsConf, endpoint, region);
+    return builder(credentials, conf, endpoint, region, bucket);
   }
 
   /**
@@ -96,37 +100,55 @@ public class STSClientFactory {
    * @return the builder to call {@code build()}
    * @throws IOException problem reading proxy secrets
    */
-  public static AWSSecurityTokenServiceClientBuilder builder(
+  public static StsClientBuilder builder(
       final Configuration conf,
       final String bucket,
-      final AWSCredentialsProvider credentials,
+      final AwsCredentialsProvider credentials,
       final String stsEndpoint,
       final String stsRegion) throws IOException {
-    final ClientConfiguration awsConf = S3AUtils.createAwsConf(conf, bucket,
-        Constants.AWS_SERVICE_IDENTIFIER_STS);
-    return builder(credentials, awsConf, stsEndpoint, stsRegion);
+    return builder(credentials, conf, stsEndpoint, stsRegion, bucket);
   }
 
   /**
    * Create the builder ready for any final configuration options.
    * Picks up connection settings from the Hadoop configuration, including
    * proxy secrets.
-   * @param awsConf AWS configuration.
+   * @param conf AWS configuration.
    * @param credentials AWS credential chain to use
    * @param stsEndpoint optional endpoint "https://sns.us-west-1.amazonaws.com"
    * @param stsRegion the region, e.g "us-west-1". Must be set if endpoint is.
    * @return the builder to call {@code build()}
    */
-  public static AWSSecurityTokenServiceClientBuilder builder(
-      final AWSCredentialsProvider credentials,
-      final ClientConfiguration awsConf,
+  public static StsClientBuilder builder(
+      final AwsCredentialsProvider credentials,
+      final Configuration conf,
       final String stsEndpoint,
-      final String stsRegion) {
-    final AWSSecurityTokenServiceClientBuilder builder
-        = AWSSecurityTokenServiceClientBuilder.standard();
+      final String stsRegion,
+      final String bucket) throws IOException {
+    final StsClientBuilder stsClientBuilder = StsClient.builder();
+
     Preconditions.checkArgument(credentials != null, "No credentials");
-    builder.withClientConfiguration(awsConf);
-    builder.withCredentials(credentials);
+
+    final ClientOverrideConfiguration.Builder clientOverrideConfigBuilder =
+        AWSClientConfig.createClientConfigBuilder(conf);
+
+    final ApacheHttpClient.Builder httpClientBuilder =
+        AWSClientConfig.createHttpClientBuilder(conf);
+
+    final RetryPolicy.Builder retryPolicyBuilder = AWSClientConfig.createRetryPolicyBuilder(conf);
+
+    final ProxyConfiguration.Builder proxyConfigBuilder =
+        AWSClientConfig.createProxyConfigurationBuilder(conf, bucket);
+
+    clientOverrideConfigBuilder.retryPolicy(retryPolicyBuilder.build());
+    httpClientBuilder.proxyConfiguration(proxyConfigBuilder.build());
+
+    stsClientBuilder
+        .httpClientBuilder(httpClientBuilder)
+        .overrideConfiguration(clientOverrideConfigBuilder.build())
+       .credentialsProvider(credentials);
+
+    // TODO: SIGNERS NOT ADDED YET.
     boolean destIsStandardEndpoint = STS_STANDARD.equals(stsEndpoint);
     if (isNotEmpty(stsEndpoint) && !destIsStandardEndpoint) {
       Preconditions.checkArgument(
@@ -134,26 +156,51 @@ public class STSClientFactory {
           "STS endpoint is set to %s but no signing region was provided",
           stsEndpoint);
       LOG.debug("STS Endpoint={}; region='{}'", stsEndpoint, stsRegion);
-      builder.withEndpointConfiguration(
-          new AwsClientBuilder.EndpointConfiguration(stsEndpoint, stsRegion));
+      stsClientBuilder.endpointOverride(getSTSEndpoint(stsEndpoint, conf))
+          .region(Region.of(stsRegion));
     } else {
       Preconditions.checkArgument(isEmpty(stsRegion),
           "STS signing region set set to %s but no STS endpoint specified",
           stsRegion);
     }
-    return builder;
+    return stsClientBuilder;
   }
 
   /**
+   * Given a endpoint string, create the endpoint URI.
+   *
+   * @param endpoint possibly null endpoint.
+   * @param conf config to build the URI from.
+   * @return an endpoint uri
+   */
+  private static URI getSTSEndpoint(String endpoint, final Configuration conf) {
+
+    boolean secureConnections = conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS);
+
+    String protocol = secureConnections ? "https" : "http";
+
+    if (!endpoint.contains("://")) {
+      endpoint = String.format("%s://%s", protocol, endpoint);
+    }
+
+    try {
+      return new URI(endpoint);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+
+  /**
    * Create an STS Client instance.
-   * @param tokenService STS instance
+   * @param stsClient STS instance
    * @param invoker invoker to use
    * @return an STS client bonded to that interface.
    */
   public static STSClient createClientConnection(
-      final AWSSecurityTokenService tokenService,
+      final StsClient stsClient,
       final Invoker invoker) {
-    return new STSClient(tokenService, invoker);
+    return new STSClient(stsClient, invoker);
   }
 
   /**
@@ -161,21 +208,19 @@ public class STSClientFactory {
    */
   public static final class STSClient implements Closeable {
 
-    private final AWSSecurityTokenService tokenService;
+    private final StsClient stsClient;
 
     private final Invoker invoker;
 
-    private STSClient(final AWSSecurityTokenService tokenService,
+    private STSClient(final StsClient stsClient,
         final Invoker invoker) {
-      this.tokenService = tokenService;
+      this.stsClient = stsClient;
       this.invoker = invoker;
     }
 
     @Override
     public void close() throws IOException {
-      // Since we are not using AbstractAWSSecurityTokenService, we
-      // don't need to worry about catching UnsupportedOperationException.
-      tokenService.shutdown();
+      stsClient.close();
     }
 
     /**
@@ -192,13 +237,13 @@ public class STSClientFactory {
         final TimeUnit timeUnit) throws IOException {
       int durationSeconds = (int) timeUnit.toSeconds(duration);
       LOG.debug("Requesting session token of duration {}", duration);
-      final GetSessionTokenRequest request = new GetSessionTokenRequest();
-      request.setDurationSeconds(durationSeconds);
+      final GetSessionTokenRequest request =
+          GetSessionTokenRequest.builder().durationSeconds(durationSeconds).build();
       return invoker.retry("request session credentials", "",
           true,
           () ->{
             LOG.info("Requesting Amazon STS Session credentials");
-            return tokenService.getSessionToken(request).getCredentials();
+            return stsClient.getSessionToken(request).credentials();
           });
     }
 
@@ -222,15 +267,14 @@ public class STSClientFactory {
         final TimeUnit timeUnit) throws IOException {
       LOG.debug("Requesting role {} with duration {}; policy = {}",
           roleARN, duration, policy);
-      AssumeRoleRequest request = new AssumeRoleRequest();
-      request.setDurationSeconds((int) timeUnit.toSeconds(duration));
-      request.setRoleArn(roleARN);
-      request.setRoleSessionName(sessionName);
+      AssumeRoleRequest.Builder requestBuilder =
+          AssumeRoleRequest.builder().durationSeconds((int) timeUnit.toSeconds(duration))
+              .roleArn(roleARN).roleSessionName(sessionName);
       if (isNotEmpty(policy)) {
-        request.setPolicy(policy);
+        requestBuilder.policy(policy);
       }
       return invoker.retry("request role credentials", "", true,
-          () -> tokenService.assumeRole(request).getCredentials());
+          () -> stsClient.assumeRole(requestBuilder.build()).credentials());
     }
   }
 }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.Credentials;
 import software.amazon.awssdk.services.sts.model.GetSessionTokenRequest;
+import software.amazon.awssdk.thirdparty.org.apache.http.client.utils.URIBuilder;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -49,8 +50,6 @@ import org.apache.hadoop.fs.s3a.Retries;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_SECURE_CONNECTIONS;
-import static org.apache.hadoop.fs.s3a.Constants.SECURE_CONNECTIONS;
 import static org.apache.hadoop.fs.s3a.auth.delegation.DelegationConstants.*;
 
 /**
@@ -174,7 +173,7 @@ public class STSClientFactory {
    */
   private static URI getSTSEndpoint(String endpoint) {
     try {
-      return new URI(endpoint);
+      return new URIBuilder().setScheme("https").setHost(endpoint).build();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(e);
     }

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
@@ -136,11 +136,11 @@ public class STSClientFactory {
 
     final RetryPolicy.Builder retryPolicyBuilder = AWSClientConfig.createRetryPolicyBuilder(conf);
 
-    final ProxyConfiguration.Builder proxyConfigBuilder =
-        AWSClientConfig.createProxyConfigurationBuilder(conf, bucket);
+    final ProxyConfiguration proxyConfig =
+        AWSClientConfig.createProxyConfiguration(conf, bucket);
 
     clientOverrideConfigBuilder.retryPolicy(retryPolicyBuilder.build());
-    httpClientBuilder.proxyConfiguration(proxyConfigBuilder.build());
+    httpClientBuilder.proxyConfiguration(proxyConfig);
 
     stsClientBuilder
         .httpClientBuilder(httpClientBuilder)

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
@@ -173,6 +173,8 @@ public class STSClientFactory {
    */
   private static URI getSTSEndpoint(String endpoint) {
     try {
+      // TODO: The URI builder is currently imported via a shaded dependency. This is due to TM
+      //  preview dependency causing some issues. 
       return new URIBuilder().setScheme("https").setHost(endpoint).build();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(e);

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/STSClientFactory.java
@@ -156,7 +156,7 @@ public class STSClientFactory {
           "STS endpoint is set to %s but no signing region was provided",
           stsEndpoint);
       LOG.debug("STS Endpoint={}; region='{}'", stsEndpoint, stsRegion);
-      stsClientBuilder.endpointOverride(getSTSEndpoint(stsEndpoint, conf))
+      stsClientBuilder.endpointOverride(getSTSEndpoint(stsEndpoint))
           .region(Region.of(stsRegion));
     } else {
       Preconditions.checkArgument(isEmpty(stsRegion),
@@ -170,19 +170,9 @@ public class STSClientFactory {
    * Given a endpoint string, create the endpoint URI.
    *
    * @param endpoint possibly null endpoint.
-   * @param conf config to build the URI from.
    * @return an endpoint uri
    */
-  private static URI getSTSEndpoint(String endpoint, final Configuration conf) {
-
-    boolean secureConnections = conf.getBoolean(SECURE_CONNECTIONS, DEFAULT_SECURE_CONNECTIONS);
-
-    String protocol = secureConnections ? "https" : "http";
-
-    if (!endpoint.contains("://")) {
-      endpoint = String.format("%s://%s", protocol, endpoint);
-    }
-
+  private static URI getSTSEndpoint(String endpoint) {
     try {
       return new URI(endpoint);
     } catch (URISyntaxException e) {

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/RoleTokenBinding.java
@@ -23,11 +23,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import com.amazonaws.services.securitytoken.model.Credentials;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.apache.hadoop.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
@@ -26,10 +26,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSSessionCredentials;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import org.apache.hadoop.classification.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,11 +35,9 @@ import software.amazon.awssdk.services.sts.StsClient;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.AWSCredentialProviderList;
-import org.apache.hadoop.fs.s3a.Constants;
 import org.apache.hadoop.fs.s3a.Invoker;
 import org.apache.hadoop.fs.s3a.Retries;
 import org.apache.hadoop.fs.s3a.S3ARetryPolicy;
-import org.apache.hadoop.fs.s3a.S3AUtils;
 import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialProvider;
 import org.apache.hadoop.fs.s3a.auth.MarshalledCredentials;
 import org.apache.hadoop.fs.s3a.auth.RoleModel;
@@ -298,7 +292,7 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
     final AwsCredentials parentCredentials = once("get credentials",
         "",
         () -> parentAuthChain.resolveCredentials());
-    hasSessionCreds = parentCredentials instanceof AWSSessionCredentials;
+    hasSessionCreds = parentCredentials instanceof AwsSessionCredentials;
 
     if (!hasSessionCreds) {
       LOG.debug("Creating STS client for {}", getDescription());

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/auth/delegation/SessionTokenBinding.java
@@ -295,8 +295,6 @@ public class SessionTokenBinding extends AbstractDelegationTokenBinding {
     // chain.
     // As no codepath (session propagation, STS creation) will work,
     // throw this.
-    // TODO: Check if changing this to .resolveCredentials() is ok.
-    //  Not clear on what is ok to break.
     final AwsCredentials parentCredentials = once("get credentials",
         "",
         () -> parentAuthChain.resolveCredentials());

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3AAWSCredentialsProvider.java
@@ -37,6 +37,9 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import static org.apache.hadoop.fs.s3a.Constants.*;
 import static org.apache.hadoop.fs.s3a.S3ATestUtils.getCSVTestPath;
@@ -77,20 +80,17 @@ public class ITestS3AAWSCredentialsProvider {
    * or a public default constructor.
    */
   static class BadCredentialsProviderConstructor
-      implements AWSCredentialsProvider {
+      implements AwsCredentialsProvider {
 
     @SuppressWarnings("unused")
     public BadCredentialsProviderConstructor(String fsUri, Configuration conf) {
     }
 
     @Override
-    public AWSCredentials getCredentials() {
-      return new BasicAWSCredentials("dummy_key", "dummy_secret");
+    public AwsCredentials resolveCredentials() {
+      return AwsBasicCredentials.create("dummy_key", "dummy_secret");
     }
 
-    @Override
-    public void refresh() {
-    }
   }
 
   @Test
@@ -125,20 +125,17 @@ public class ITestS3AAWSCredentialsProvider {
     fail("Expected exception - got " + fs);
   }
 
-  static class BadCredentialsProvider implements AWSCredentialsProvider {
+  static class BadCredentialsProvider implements AwsCredentialsProvider {
 
     @SuppressWarnings("unused")
     public BadCredentialsProvider(Configuration conf) {
     }
 
     @Override
-    public AWSCredentials getCredentials() {
-      return new BasicAWSCredentials("bad_key", "bad_secret");
+    public AwsCredentials resolveCredentials() {
+      return AwsBasicCredentials.create("bad_key", "bad_secret");
     }
 
-    @Override
-    public void refresh() {
-    }
   }
 
   @Test
@@ -157,7 +154,6 @@ public class ITestS3AAWSCredentialsProvider {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testAnonymousProvider() throws Exception {
     Configuration conf = new Configuration();
     conf.set(AWS_CREDENTIALS_PROVIDER,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATemporaryCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/ITestS3ATemporaryCredentials.java
@@ -27,12 +27,13 @@ import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import com.amazonaws.services.securitytoken.model.Credentials;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.s3a.auth.MarshalledCredentialBinding;
@@ -120,7 +121,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
     credentials = testFS.shareCredentials("testSTS");
 
     String bucket = testFS.getBucket();
-    AWSSecurityTokenServiceClientBuilder builder = STSClientFactory.builder(
+    StsClientBuilder builder = STSClientFactory.builder(
         conf,
         bucket,
         credentials,
@@ -154,7 +155,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
 
     // now create an invalid set of credentials by changing the session
     // token
-    conf2.set(SESSION_TOKEN, "invalid-" + sessionCreds.getSessionToken());
+    conf2.set(SESSION_TOKEN, "invalid-" + sessionCreds.sessionToken());
     try (S3AFileSystem fs = S3ATestUtils.createTestFileSystem(conf2)) {
       createAndVerifyFile(fs, path("testSTSInvalidToken"), TEST_FILE_SIZE);
       fail("Expected an access exception, but file access to "
@@ -183,7 +184,7 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
     conf.set(SECRET_KEY, "secretkey");
     conf.set(SESSION_TOKEN, "");
     LambdaTestUtils.intercept(CredentialInitializationException.class,
-        () -> new TemporaryAWSCredentialsProvider(conf).getCredentials());
+        () -> new TemporaryAWSCredentialsProvider(conf).resolveCredentials());
   }
 
   /**
@@ -370,15 +371,15 @@ public class ITestS3ATemporaryCredentials extends AbstractS3ATestBase {
             getFileSystem().shareCredentials("test");
         DurationInfo ignored = new DurationInfo(LOG, "requesting credentials")) {
       Configuration conf = new Configuration(getContract().getConf());
-      ClientConfiguration awsConf =
-          S3AUtils.createAwsConf(conf, null, AWS_SERVICE_IDENTIFIER_STS);
+
       return intercept(clazz, exceptionText,
           () -> {
-            AWSSecurityTokenService tokenService =
+            StsClient tokenService =
                 STSClientFactory.builder(parentCreds,
-                    awsConf,
+                    conf,
                     endpoint,
-                    region)
+                    region,
+                    getFileSystem().getBucket())
                     .build();
             Invoker invoker = new Invoker(new S3ARetryPolicy(conf),
                 LOG_AT_ERROR);

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -67,6 +67,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.io.Closeable;
 import java.io.File;
@@ -612,8 +613,7 @@ public final class S3ATestUtils {
    * @return a set of credentials
    * @throws IOException on a failure
    */
-  @SuppressWarnings("deprecation")
-  public static AWSCredentialsProvider buildAwsCredentialsProvider(
+  public static AwsCredentialsProvider buildAwsCredentialsProvider(
       final Configuration conf)
       throws IOException {
     assumeSessionTestsEnabled(conf);
@@ -668,7 +668,7 @@ public final class S3ATestUtils {
     MarshalledCredentials sc = MarshalledCredentialBinding
         .requestSessionCredentials(
           buildAwsCredentialsProvider(conf),
-          S3AUtils.createAwsConf(conf, bucket, AWS_SERVICE_IDENTIFIER_STS),
+          conf,
           conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT,
               DEFAULT_ASSUMED_ROLE_STS_ENDPOINT),
           conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT_REGION,

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/S3ATestUtils.java
@@ -674,7 +674,8 @@ public final class S3ATestUtils {
           conf.getTrimmed(ASSUMED_ROLE_STS_ENDPOINT_REGION,
               ASSUMED_ROLE_STS_ENDPOINT_REGION_DEFAULT),
           duration,
-          new Invoker(new S3ARetryPolicy(conf), Invoker.LOG_EVENT));
+          new Invoker(new S3ARetryPolicy(conf), Invoker.LOG_EVENT),
+           bucket );
     sc.validate("requested session credentials: ",
         MarshalledCredentials.CredentialTypeRequired.SessionOnly);
     return sc;

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/TestS3AAWSCredentialsProvider.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.util.Sets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -351,12 +352,12 @@ public class TestS3AAWSCredentialsProvider {
       List<Class<?>> expectedClasses,
       AWSCredentialProviderList list) {
     assertNotNull(list);
-    List<AWSCredentialsProvider> providers = list.getProviders();
+    List<AwsCredentialsProvider> providers = list.getProviders();
     assertEquals(expectedClasses.size(), providers.size());
     for (int i = 0; i < expectedClasses.size(); ++i) {
       Class<?> expectedClass =
           expectedClasses.get(i);
-      AWSCredentialsProvider provider = providers.get(i);
+      AwsCredentialsProvider provider = providers.get(i);
       assertNotNull(
           String.format("At position %d, expected class is %s, but found null.",
               i, expectedClass), provider);
@@ -390,7 +391,7 @@ public class TestS3AAWSCredentialsProvider {
     // verify you can't get credentials from it
     NoAuthWithAWSException noAuth = intercept(NoAuthWithAWSException.class,
         AWSCredentialProviderList.NO_AWS_CREDENTIAL_PROVIDERS,
-        () -> providers.getCredentials());
+        () -> providers.resolveCredentials());
     // but that it closes safely
     providers.close();
 
@@ -439,11 +440,10 @@ public class TestS3AAWSCredentialsProvider {
     providers.close();
     assertEquals("Ref count after close() for " + providers,
         0, providers.getRefCount());
-    providers.refresh();
 
     intercept(NoAuthWithAWSException.class,
         AWSCredentialProviderList.CREDENTIALS_REQUESTED_WHEN_CLOSED,
-        () -> providers.getCredentials());
+        () -> providers.resolveCredentials());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/ITestAssumeRole.java
@@ -33,6 +33,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
@@ -140,7 +141,6 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testCreateCredentialProvider() throws IOException {
     describe("Create the credential provider");
 
@@ -148,13 +148,12 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     try (AssumedRoleCredentialProvider provider
              = new AssumedRoleCredentialProvider(uri, conf)) {
       LOG.info("Provider is {}", provider);
-      AWSCredentials credentials = provider.getCredentials();
+      AwsCredentials credentials = provider.resolveCredentials();
       assertNotNull("Null credentials from " + provider, credentials);
     }
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testCreateCredentialProviderNoURI() throws IOException {
     describe("Create the credential provider");
 
@@ -162,7 +161,7 @@ public class ITestAssumeRole extends AbstractS3ATestBase {
     try (AssumedRoleCredentialProvider provider
              = new AssumedRoleCredentialProvider(null, conf)) {
       LOG.info("Provider is {}", provider);
-      AWSCredentials credentials = provider.getCredentials();
+      AwsCredentials credentials = provider.resolveCredentials();
       assertNotNull("Null credentials from " + provider, credentials);
     }
   }

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestMarshalledCredentials.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/TestMarshalledCredentials.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import com.amazonaws.auth.AWSCredentials;
 import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
@@ -94,13 +95,13 @@ public class TestMarshalledCredentials extends HadoopTestBase {
         new Configuration(false),
         credentials,
         MarshalledCredentials.CredentialTypeRequired.SessionOnly);
-    AWSCredentials aws = provider.getCredentials();
+    AwsCredentials aws = provider.resolveCredentials();
     assertEquals(credentials.toString(),
         credentials.getAccessKey(),
-        aws.getAWSAccessKeyId());
+        aws.accessKeyId());
     assertEquals(credentials.toString(),
         credentials.getSecretKey(),
-        aws.getAWSSecretKey());
+        aws.secretAccessKey());
     // because the credentials are set to full only, creation will fail
   }
 
@@ -119,7 +120,7 @@ public class TestMarshalledCredentials extends HadoopTestBase {
         MarshalledCredentials.CredentialTypeRequired.FullOnly);
     // because the credentials are set to full only, creation will fail
     intercept(NoAuthWithAWSException.class, "test",
-        () ->  provider.getCredentials());
+        () ->  provider.resolveCredentials());
   }
 
   /**

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/CountInvocationsProvider.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/CountInvocationsProvider.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.fs.s3a.auth.delegation;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import org.apache.hadoop.fs.s3a.CredentialInitializationException;
 
@@ -29,21 +29,16 @@ import org.apache.hadoop.fs.s3a.CredentialInitializationException;
  * Simple AWS credential provider which counts how often it is invoked.
  */
 public class CountInvocationsProvider
-    implements AWSCredentialsProvider {
+    implements AwsCredentialsProvider {
 
   public static final String NAME = CountInvocationsProvider.class.getName();
 
   public static final AtomicLong COUNTER = new AtomicLong(0);
 
   @Override
-  public AWSCredentials getCredentials() {
+  public AwsCredentials resolveCredentials() {
     COUNTER.incrementAndGet();
     throw new CredentialInitializationException("no credentials");
-  }
-
-  @Override
-  public void refresh() {
-
   }
 
   public static long getInvocationCount() {

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationInFileystem.java
@@ -255,7 +255,6 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void testAddTokensFromFileSystem() throws Throwable {
     describe("verify FileSystem.addDelegationTokens() collects tokens");
     S3AFileSystem fs = getFileSystem();
@@ -277,7 +276,7 @@ public class ITestSessionDelegationInFileystem extends AbstractDelegationIT {
     AWSCredentialProviderList providerList = requireNonNull(
         delegationTokens.getCredentialProviders(), "providers");
 
-    providerList.getCredentials();
+    providerList.resolveCredentials();
   }
 
   @Test

--- a/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
+++ b/hadoop-tools/hadoop-aws/src/test/java/org/apache/hadoop/fs/s3a/auth/delegation/ITestSessionDelegationTokens.java
@@ -28,6 +28,8 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.s3a.S3AEncryptionMethods;
@@ -188,9 +190,9 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
       dt2.start();
 
       dt2.resetTokenBindingToDT(originalDT);
-      final AWSSessionCredentials awsSessionCreds
+      final AwsSessionCredentials awsSessionCreds
           = verifySessionCredentials(
-          dt2.getCredentialProviders().getCredentials());
+          dt2.getCredentialProviders().resolveCredentials());
       final MarshalledCredentials origCreds = fromAWSCredentials(
           awsSessionCreds);
 
@@ -249,7 +251,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
    * @return the retrieved DT. This is only for error reporting.
    * @throws IOException failure.
    */
-  @SuppressWarnings({"OptionalGetWithoutIsPresent", "deprecation"})
+  @SuppressWarnings({"OptionalGetWithoutIsPresent"})
   protected AbstractS3ATokenIdentifier verifyCredentialPropagation(
       final S3AFileSystem fs,
       final MarshalledCredentials session,
@@ -278,7 +280,7 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
       LOG.info("Regenerated DT is {}", newDT);
       final MarshalledCredentials creds2 = fromAWSCredentials(
           verifySessionCredentials(
-              delegationTokens2.getCredentialProviders().getCredentials()));
+              delegationTokens2.getCredentialProviders().resolveCredentials()));
       assertEquals("Credentials", session, creds2);
       assertTrue("Origin in " + boundId,
           boundId.getOrigin()
@@ -287,12 +289,12 @@ public class ITestSessionDelegationTokens extends AbstractDelegationIT {
     }
   }
 
-  private AWSSessionCredentials verifySessionCredentials(
-      final AWSCredentials creds) {
-    AWSSessionCredentials session = (AWSSessionCredentials) creds;
-    assertNotNull("access key", session.getAWSAccessKeyId());
-    assertNotNull("secret key", session.getAWSSecretKey());
-    assertNotNull("session token", session.getSessionToken());
+  private AwsSessionCredentials verifySessionCredentials(
+      final AwsCredentials creds) {
+    AwsSessionCredentials session = (AwsSessionCredentials) creds;
+    assertNotNull("access key", session.accessKeyId());
+    assertNotNull("secret key", session.secretAccessKey());
+    assertNotNull("session token", session.sessionToken());
     return session;
   }
 


### PR DESCRIPTION
Key decisions:

- All credential provider classes implemented in Hadoop now implement V2's `AwsCredentialProvider` .
- `AWSCredentialProviderList` also implements `AwsCredentialProvider`. But keeps existing constructors and add methods for V1 credential providers, and wraps V1 cred providers in the adapter here. This means that custom binding classes in delegation tokens, as well as any custom cred providers will continue to work. 
- Added a new `getCredentials()` method in `AWSCredentialProviderList`, which ensured that custom binding classes which are calling `AWSCredentialProviderList.getCredentials()`, continue to work. 

Failing tests:

ITestS3AWSCredentialsProvider.testBadCredentials - Fails as the region resolution in `DefaultS3ClientFactory.testBadCredentials()` fails with the bad credential provider, and so ends up using the default US_EAST_1 region. What should happen when region resolution fails is to be discussed. Probably some retries, and in case of bad credentials fail fs initialisation. 
